### PR TITLE
[STREAMPIPES-446] fix wrong behaviour for multiple data sources

### DIFF
--- a/ui/src/app/data-explorer/components/widgets/line-chart/config/line-chart-widget-config.component.html
+++ b/ui/src/app/data-explorer/components/widgets/line-chart/config/line-chart-widget-config.component.html
@@ -27,25 +27,6 @@
         </mat-select>
     </mat-form-field>
 
-    <!-- <sp-select-properties
-            label="Select Properties"
-            multiple=true
-            (changeSelectedProperties)="setSelectedProperties($event)"
-            [availableProperties]="fieldProvider.numericFields"
-            [selectedProperties]="currentlyConfiguredWidget.visualizationConfig.selectedLineChartProperties">
-    </sp-select-properties>
-
-    <mat-form-field color="accent" *ngFor="let field of fieldProvider.numericFields" fxFlex="100">
-        <b>{{field.runtimeName}}</b>
-        <input matInput
-            [(colorPicker)]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName]"
-            [style.background]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName]" required
-            [cpPosition]="'bottom'"
-            [cpPresetColors]="presetColors"
-            (colorPickerSelect)="triggerDataRefresh()"
-            autocomplete="off"/>
-    </mat-form-field> -->
-
     <sp-select-color-properties
         label="Select Properties"
         multiple=true

--- a/ui/src/app/data-explorer/components/widgets/line-chart/config/line-chart-widget-config.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/line-chart/config/line-chart-widget-config.component.ts
@@ -45,6 +45,7 @@ export class LineChartWidgetConfigComponent extends BaseWidgetConfig<LineChartWi
 
   setSelectedProperties(selectedColumns: DataExplorerField[]) {
     this.currentlyConfiguredWidget.visualizationConfig.selectedLineChartProperties = selectedColumns;
+    console.log(selectedColumns);
     // this.currentlyConfiguredWidget.dataConfig.yKeys = this.getRuntimeNames(selectedColumns);
     this.triggerDataRefresh();
   }
@@ -77,7 +78,7 @@ export class LineChartWidgetConfigComponent extends BaseWidgetConfig<LineChartWi
   protected initWidgetConfig(): LineCartVisConfig {
     const colors = {};
     this.fieldProvider.numericFields.map((field, index) => {
-      colors[field.runtimeName] = this.presetColors[index];
+      colors[field.runtimeName + field.sourceIndex] = this.presetColors[index];
     });
     return {
       forType: this.getWidgetType(),

--- a/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.html
+++ b/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.html
@@ -39,8 +39,8 @@
         <div fxFlex fxLayoutAlign="end center" *ngIf="isSelected(field)">
             <mat-form-field color="accent" fxFlex="100">
                 <input matInput
-                    [(colorPicker)]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName]"
-                    [style.background]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName]" required
+                    [(colorPicker)]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName + field.sourceIndex.toString()]"
+                    [style.background]="currentlyConfiguredWidget.visualizationConfig.chosenColor[field.runtimeName + field.sourceIndex.toString()]" required
                     [cpPosition]="'bottom'"
                     [cpPresetColors]="presetColors"
                     (colorPickerSelect)="triggerDataRefresh()"

--- a/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.ts
+++ b/ui/src/app/data-explorer/components/widgets/utils/select-color-properties/select-color-properties.component.ts
@@ -65,12 +65,12 @@ export class SelectColorPropertiesComponent implements OnInit {
   }
 
   isSelected(field: DataExplorerField): boolean {
-    return this.selectedProperties.find(sp => sp.fullDbName === field.fullDbName) !== undefined;
+    return this.selectedProperties.find(sp => sp.fullDbName === field.fullDbName && sp.sourceIndex === field.sourceIndex) !== undefined;
   }
 
   toggleFieldSelection(field: DataExplorerField) {
     if (this.isSelected(field)) {
-      this.selectedProperties = this.selectedProperties.filter(sp => !(sp.fullDbName === field.fullDbName));
+      this.selectedProperties = this.selectedProperties.filter(sp => !(sp.fullDbName === field.fullDbName && sp.sourceIndex === field.sourceIndex));
     } else {
       this.selectedProperties.push(field);
     }


### PR DESCRIPTION
### Purpose
Fixed line chart coloring for data-explorer, when multiple data sources are available. Especially when the same data sources and properties are used more than once (e.g. to apply individual filters).