### PR TITLE
[STREAMPIPES-648] Add license header check to checkstyle.xml

### DIFF
--- a/tools/maven/checkstyle-header.txt
+++ b/tools/maven/checkstyle-header.txt
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -27,6 +27,11 @@ page at http://checkstyle.sourceforge.net/config.html -->
 <module name="Checker">
     <property name="severity" value="error"/>
 
+    <module name="Header">
+        <property name="headerFile" value="tools/maven/checkstyle-header.txt"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <module name="FileTabCharacter">
         <!-- Checks that there are no tab characters in the file. -->
     </module>


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  

### Purpose
This PR adds a check for license headers to the checkstyle plugin as discussed in [1]

Fixes: [STREAMPIPES-648]

[1] https://lists.apache.org/thread/6o8xsdvky78h7mfs0dy18pl6dh3mfbyv
