### PR TITLE
Fix the checkstyle plugin doesn't fail on violation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1810,12 +1810,16 @@ IoT data streams.
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
-			<!-- TODO: Add the maven-checkstyle-plugin back when https://github.com/apache/streampipes/issues/820 is completed-->
-			<!--			<plugin>-->
-			<!--				<groupId>org.apache.maven.plugins</groupId>-->
-			<!--				<artifactId>maven-checkstyle-plugin</artifactId>-->
-			<!--				<version>${maven-checkstyle-plugin.version}</version>-->
-			<!--			</plugin>-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>${maven-checkstyle-plugin.version}</version>
+				<configuration>
+					<logViolationsToConsole>false</logViolationsToConsole>
+					<failOnViolation>false</failOnViolation>
+				</configuration>
+				<inherited>false</inherited>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1584,8 +1584,8 @@ IoT data streams.
 						<includeTestSourceDirectory>true</includeTestSourceDirectory>
 						<configLocation>tools/maven/checkstyle.xml</configLocation>
 						<encoding>UTF-8</encoding>
-						<logViolationsToConsole>false</logViolationsToConsole>
-						<failOnViolation>false</failOnViolation>
+						<logViolationsToConsole>true</logViolationsToConsole>
+						<failOnViolation>true</failOnViolation>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -1810,15 +1810,12 @@ IoT data streams.
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-checkstyle-plugin</artifactId>
-				<version>${maven-checkstyle-plugin.version}</version>
-				<configuration>
-					<logViolationsToConsole>false</logViolationsToConsole>
-					<failOnViolation>false</failOnViolation>
-				</configuration>
-			</plugin>
+			<!-- TODO: Add the maven-checkstyle-plugin back when https://github.com/apache/streampipes/issues/820 is completed-->
+			<!--			<plugin>-->
+			<!--				<groupId>org.apache.maven.plugins</groupId>-->
+			<!--				<artifactId>maven-checkstyle-plugin</artifactId>-->
+			<!--				<version>${maven-checkstyle-plugin.version}</version>-->
+			<!--			</plugin>-->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
Fix https://github.com/apache/streampipes/issues/820#issuecomment-1339663188
The root cause is that the plugin configuration of the submodule is inherited from the parent project. We have skipped `failOnViolation` in the parent pom. Therefore the submodule also skips that.

This PR makes the checkstyle configuration of the parent module not be inherited to the submodule.
After we complete this issue: https://github.com/apache/streampipes/issues/820, we can turn it back and let the checkstyle configuration of the parent module apply to the whole project.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
