### PR TITLE
fix: fix shebang with apache header

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd ui && npm run lint-staged


### PR DESCRIPTION
I think there is an issue with the pre-commit hook on windows, because the Shebang should be on the first line of the script. Because of the apache header it could not be interpreted correctly.