### PR TITLE
Validate CLI commands and exit with message if any error's.

### DIFF
--- a/installer/cli/bin/commands/env
+++ b/installer/cli/bin/commands/env
@@ -49,6 +49,11 @@ if [ "$#" -gt 3 ]; then
     fatal "Illegal number of arguments, see 'streampipes ${0##*/} --help'"
 fi
 
+if ! docker info > /dev/null 2>&1; then
+  echo "Streampipes environment uses docker, and it isn't running - please start docker and try again!"
+  exit 1
+fi
+
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -i|--inspect)


### PR DESCRIPTION
Issue: https://github.com/apache/streampipes/issues/964

### Purpose
For the CLI installer's command, in case of an error, it should exit with a message on the console output.

PR introduces (a) breaking change(s): <yes/no> no

PR introduces (a) deprecation(s): <yes/no> no
