### PR TITLE
[#1121] Add replay once option to FileStreamProtocol

### DIFF
--- a/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/resources/org.apache.streampipes.connect.iiot.protocol.stream.file/strings.en
+++ b/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/resources/org.apache.streampipes.connect.iiot.protocol.stream.file/strings.en
@@ -17,7 +17,7 @@
 
 
 org.apache.streampipes.connect.iiot.protocol.stream.file.title=File Stream
-org.apache.streampipes.connect.iiot.protocol.stream.file=Continuously streams the content from a file.
+org.apache.streampipes.connect.iiot.protocol.stream.file.description=Continuously streams the content from a file.
 
 filePath.title=File
 filePath.description=File Path
@@ -26,8 +26,19 @@ replaceTimestamp.title=Use current time
 replaceTimestamp.description=Replace Event Time with Current Timestamp
 
 speed.title=Replay Speed
-speed.description=original = 1; speedup 2x = 2; half speed  =  0.5
+speed.description=
+
+speedUp.title=Speed Up
+speedUp.description=original = 1; speedup 2x = 2; half speed  =  0.5
 
 replayOnce.title=Replay Once
 replayOnce.description='yes' file is only replayed once, 'no' the file is replayed till adapter is stopped
 
+keepOriginalTime.title=Keep original time
+keepOriginalTime.description=
+
+speedUpFactor.title=Speed Up Factor
+speedUpFactor.description=
+
+fastest.title=Fastest (Ignore original time)
+fastest.description=

--- a/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/resources/org.apache.streampipes.connect.iiot.protocol.stream.file/strings.en
+++ b/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/resources/org.apache.streampipes.connect.iiot.protocol.stream.file/strings.en
@@ -28,3 +28,6 @@ replaceTimestamp.description=Replace Event Time with Current Timestamp
 speed.title=Replay Speed
 speed.description=original = 1; speedup 2x = 2; half speed  =  0.5
 
+replayOnce.title=Replay Once
+replayOnce.description='yes' file is only replayed once, 'no' the file is replayed till adapter is stopped
+

--- a/ui/cypress/tests/adapter/fileStream.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/fileStream.smoke.spec.ts
@@ -38,7 +38,6 @@ describe(
             const adapterInput = GenericAdapterBuilder.create('File_Stream')
                 .setName('File Stream Adapter Test')
                 .setTimestampProperty('timestamp')
-                .addProtocolInput('input', 'speed', '1')
                 .addProtocolInput('checkbox', 'replaceTimestamp', 'check')
                 .setFormat('csv')
                 .addFormatInput('input', 'delimiter', ';')

--- a/ui/cypress/tests/adapter/persistInDataLake.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/persistInDataLake.smoke.spec.ts
@@ -32,7 +32,6 @@ describe('Test File Stream Adapter', () => {
             .setName('File Stream Adapter Test')
             .setTimestampProperty('timestamp')
             .setStoreInDataLake()
-            .addProtocolInput('input', 'speed', '1')
             .addProtocolInput('checkbox', 'replaceTimestamp', 'check')
             .setFormat('csv')
             .addFormatInput('input', 'delimiter', ';')


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
- Fixes #1121
- Implements the ability for the `FileStreamAdapter` to replay a file only once
- Additional parameter added to the `FileStreamAdapter` configuration to enable this feature
- Default behavior set to continuously replay the file

### Remarks
@dominikriemer do we need an update script for old adapters using the `FileStreamAdapters`?
Since we will update the connection API, should we implement this update now or later for the new data model?
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): yes
PR introduces (a) deprecation(s): no
