### PR TITLE
[#1040] rework schema definitions in geo processors

### DIFF
--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/latlngtojtspoint/LatLngToJtsPointProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/latlngtojtspoint/LatLngToJtsPointProcessor.java
@@ -47,7 +47,7 @@ public class LatLngToJtsPointProcessor extends StreamPipesDataProcessor {
   private static final String LAT_KEY = "latitude-key";
   private static final String LNG_KEY = "longitude-key";
   private static final String EPSG_KEY = "epsg-key";
-  private static final String WKT_RUNTIME = "geomWKT";
+  private static final String GEOMETRY_RUNTIME = "geometry";
   private String latitudeMapper;
   private String longitudeMapper;
   private String epsgMapper;
@@ -76,7 +76,7 @@ public class LatLngToJtsPointProcessor extends StreamPipesDataProcessor {
         .outputStrategy(
             OutputStrategies.append(
                 PrimitivePropertyBuilder
-                    .create(Datatypes.String, WKT_RUNTIME)
+                    .create(Datatypes.String, GEOMETRY_RUNTIME)
                     .domainProperty("http://www.opengis.net/ont/geosparql#Geometry")
                     .build()
             )
@@ -101,7 +101,11 @@ public class LatLngToJtsPointProcessor extends StreamPipesDataProcessor {
     Point geom = SpGeometryBuilder.createSPGeom(lng, lat, epsg);
 
     if (!geom.isEmpty()) {
-      event.addField(WKT_RUNTIME, geom.toString());
+      // if activated the stream fails at all
+      //event.removeFieldBySelector(latitudeMapper);
+      //event.removeFieldBySelector(longitudeMapper);
+      event.addField(GEOMETRY_RUNTIME, geom.toString());
+
       LOG.debug("Created Geometry: " + geom.toString());
       collector.collect(event);
     } else {

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/latlngtojtspoint/LatLngToJtsPointProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/latlngtojtspoint/LatLngToJtsPointProcessor.java
@@ -101,9 +101,6 @@ public class LatLngToJtsPointProcessor extends StreamPipesDataProcessor {
     Point geom = SpGeometryBuilder.createSPGeom(lng, lat, epsg);
 
     if (!geom.isEmpty()) {
-      // if activated the stream fails at all
-      //event.removeFieldBySelector(latitudeMapper);
-      //event.removeFieldBySelector(longitudeMapper);
       event.addField(GEOMETRY_RUNTIME, geom.toString());
 
       LOG.debug("Created Geometry: " + geom.toString());

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/reprojection/ReprojectionProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/reprojection/ReprojectionProcessor.java
@@ -49,7 +49,7 @@ public class ReprojectionProcessor extends StreamPipesDataProcessor {
   public static final String GEOM_KEY = "geom-key";
   public static final String SOURCE_EPSG_KEY = "source-epsg-key";
   public static final String TARGET_EPSG_KEY = "target-epsg-key";
-  public static final String GEOM_RUNTIME = "geomWKT";
+  public static final String GEOMETRY_RUNTIME = "geometry";
   public static final String EPSG_RUNTIME = "epsg";
   private String geometryMapper;
   private String sourceEpsgMapper;
@@ -134,7 +134,7 @@ public class ReprojectionProcessor extends StreamPipesDataProcessor {
 
     if (!reprojected.isEmpty()) {
       event.updateFieldBySelector("s0::" + EPSG_RUNTIME, targetEpsg);
-      event.updateFieldBySelector("s0::" + GEOM_RUNTIME, reprojected.toText());
+      event.updateFieldBySelector("s0::" + GEOMETRY_RUNTIME, reprojected.toText());
 
       collector.collect(event);
     } else {

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/reprojection/ReprojectionProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/reprojection/ReprojectionProcessor.java
@@ -32,8 +32,6 @@ import org.apache.streampipes.sdk.helpers.EpRequirements;
 import org.apache.streampipes.sdk.helpers.Labels;
 import org.apache.streampipes.sdk.helpers.Locales;
 import org.apache.streampipes.sdk.helpers.OutputStrategies;
-import org.apache.streampipes.sdk.helpers.SupportedFormats;
-import org.apache.streampipes.sdk.helpers.SupportedProtocols;
 import org.apache.streampipes.sdk.utils.Assets;
 import org.apache.streampipes.wrapper.context.EventProcessorRuntimeContext;
 import org.apache.streampipes.wrapper.routing.SpOutputCollector;
@@ -75,8 +73,6 @@ public class ReprojectionProcessor extends StreamPipesDataProcessor {
             .build())
         .outputStrategy(OutputStrategies.keep())
         .requiredIntegerParameter(Labels.withId(TARGET_EPSG_KEY), 32632)
-        .supportedFormats(SupportedFormats.jsonFormat())
-        .supportedProtocols(SupportedProtocols.kafka())
         .build();
   }
 

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/trajectory/TrajectoryFromPointsProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/jts/processor/trajectory/TrajectoryFromPointsProcessor.java
@@ -51,8 +51,9 @@ public class TrajectoryFromPointsProcessor extends StreamPipesDataProcessor {
   private static final String SUBPOINTS_KEY = "subpoints-key";
   private static final String DESCRIPTION_KEY = "description-key";
   private static final String TRAJECTORY_KEY = "trajectory-key";
-  private static final String TRAJECTORY_RUNTIME = "trajectoryWKT";
-  private static final String DESCRIPTION_RUNTIME = "trajectoryDescription";
+  private static final String TRAJECTORY_GEOMETRY_RUNTIME = "trajectory-geometry";
+  private static final String TRAJECTORY_EPSG_RUNTIME = "trajectory-epsg";
+  private static final String DESCRIPTION_RUNTIME = "trajectory-description";
   private String pointMapper;
   private String epsgMapper;
   private String mValueMapper;
@@ -96,8 +97,12 @@ public class TrajectoryFromPointsProcessor extends StreamPipesDataProcessor {
                     SO.TEXT),
                 EpProperties.stringEp(
                     Labels.withId(TRAJECTORY_KEY),
-                    TRAJECTORY_RUNTIME,
-                    "http://www.opengis.net/ont/geosparql#Geometry")
+                    TRAJECTORY_GEOMETRY_RUNTIME,
+                    "http://www.opengis.net/ont/geosparql#Geometry"),
+                EpProperties.integerEp(
+                    Labels.withId(EPSG_KEY),
+                    TRAJECTORY_EPSG_RUNTIME,
+                "http://data.ign.fr/def/ignf#CartesianCS")
             )
         )
         .build();
@@ -131,7 +136,8 @@ public class TrajectoryFromPointsProcessor extends StreamPipesDataProcessor {
     LineString geom = trajectory.returnAsLineString(eventGeom.getFactory());
     // adds to stream
     event.addField(DESCRIPTION_RUNTIME, trajectory.getDescription());
-    event.addField(TRAJECTORY_RUNTIME, geom.toString());
+    event.addField(TRAJECTORY_GEOMETRY_RUNTIME, geom.toString());
+    event.addField(TRAJECTORY_EPSG_RUNTIME, epsg);
     collector.collect(event);
   }
 

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/latlong/processor/speedcalculator/SpeedCalculatorProcessor.java
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/java/org/apache/streampipes/processors/geo/jvm/latlong/processor/speedcalculator/SpeedCalculatorProcessor.java
@@ -49,7 +49,7 @@ public class SpeedCalculatorProcessor extends StreamPipesDataProcessor {
   private static final String LATITUDE_KEY = "latitude-key";
   private static final String LONGITUDE_KEY = "longitude-key";
   private static final String COUNT_WINDOW_KEY = "count-window-key";
-  private static final String SPEED_KEY = "speed-key";
+  private static final String SPEED_RUNTIME_NAME = "speed";
   private String latitudeFieldMapper;
   private String longitudeFieldMapper;
   private String timestampFieldMapper;
@@ -75,7 +75,7 @@ public class SpeedCalculatorProcessor extends StreamPipesDataProcessor {
         .requiredIntegerParameter(Labels.withId(COUNT_WINDOW_KEY))
         .outputStrategy(
             OutputStrategies.append(PrimitivePropertyBuilder
-                .create(Datatypes.Float, SPEED_KEY)
+                .create(Datatypes.Float, SPEED_RUNTIME_NAME)
                 .domainProperty(SO.NUMBER)
                 .measurementUnit(URI.create("http://qudt.org/vocab/unit#KilometerPerHour"))
                 .build())
@@ -98,7 +98,7 @@ public class SpeedCalculatorProcessor extends StreamPipesDataProcessor {
     if (this.buffer.isFull()) {
       Event firstEvent = (Event) buffer.get();
       double speed = calculateSpeed(firstEvent, event);
-      event.addField(SPEED_KEY, speed);
+      event.addField(SPEED_RUNTIME_NAME, speed);
       collector.collect(event);
     }
     this.buffer.add(event);

--- a/streampipes-extensions/streampipes-processors-geo-jvm/src/main/resources/org.apache.streampipes.processors.geo.jvm.jts.processor.reprojection/strings.en
+++ b/streampipes-extensions/streampipes-processors-geo-jvm/src/main/resources/org.apache.streampipes.processors.geo.jvm.jts.processor.reprojection/strings.en
@@ -18,11 +18,11 @@
 org.apache.streampipes.processors.geo.jvm.jts.processor.reprojection.title=Geo CRS Reprojection
 org.apache.streampipes.processors.geo.jvm.jts.processor.reprojection.description=Coordinate reprojection from source to target CRS
 
-wkt-key=WKT.title=WKT
-wkt-key=WKT.description=Geometry
+geom-key.title=WKT
+geom-key.description=Geometry
 
 source-epsg-key.title=CRS of Input Geometry
 source-epsg-key.description=EPSG-Code of input point
 
-target_epsg-key.title=Target CRS
-target_epsg-key.description=EPSG-Code of target CRS
+target-epsg-key.title=Target CRS
+target-epsg-key.description=EPSG-Code of target CRS


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
#1040  improve naming of runtime names and add missing epsg field in trajectory

### Remarks

PR introduces (a) breaking change(s): yes
tested with all changes according to 
https://cwiki.apache.org/confluence/x/QZBbDg
https://cwiki.apache.org/confluence/x/RpBbDg
https://cwiki.apache.org/confluence/x/SZBbDg
https://cwiki.apache.org/confluence/x/U5BbDg
https://cwiki.apache.org/confluence/x/XJBbDg

PR introduces (a) deprecation(s): no

### Breaking changes
* `LatLngToJtsPointProcessor`: Rename schema field `WKT_RUNTIME` to `GEOMETRY_RUNTIME`
* `ReprojectionProcessor`: Rename schema field `GEOM_RUNTIME` to `GEOMETRY_RUNTIME`
* `TrajectoryFromPointsProcessor`: Introduce schema field `TRAJECTORY_GEOMETRY_RUNTIME` and rename `TRAJECTORY_RUNTIME` to  `TRAJECTORY_EPSG_RUNTIME`
* `HaversineDistanceCalculatorProcessor`: Rename schema field `CALCULATED_DISTANCE_KEY` to `DISTANCE_RUNTIME_NAME`
* `SpeedCalculatorProcessor`: Rename schema field `SPEED_KEY` to `SPEED_RUNTIME_NAME`