### PR TITLE
[hotfix] Fix bug in time selection of data explorer cypress tests

### DIFF
--- a/ui/cypress/support/utils/datalake/DataLakeUtils.ts
+++ b/ui/cypress/support/utils/datalake/DataLakeUtils.ts
@@ -84,9 +84,10 @@ export class DataLakeUtils {
     ) {
         DataLakeUtils.goToDatalake();
         DataLakeUtils.createAndEditDataView(dataViewName);
+
         DataLakeUtils.selectTimeRange(
-            new Date(2020, 10, 20, 22, 44),
-            new Date(2021, 10, 20, 22, 44),
+            new Date(2015, 10, 20, 22, 44),
+            DataLakeUtils.getFutureDate(),
         );
         // DataLakeUtils.addNewWidget();
         DataLakeUtils.selectDataSet(dataSet);
@@ -304,9 +305,36 @@ export class DataLakeUtils {
     }
 
     public static selectTimeRange(from: Date, to: Date) {
-        cy.dataCy('1_year').click();
-        // TODO fix time range selection
-        // DataLakeUtils.setTimeInput('time-range-from', from);
-        // DataLakeUtils.setTimeInput('time-range-to', to);
+        DataLakeUtils.setTimeInput('time-range-from', from);
+        DataLakeUtils.clickSetTime();
+        DataLakeUtils.setTimeInput('time-range-to', to);
+        DataLakeUtils.clickSetTime();
+    }
+
+    public static setTimeInput(field: string, date: Date) {
+        cy.dataCy(field)
+            .clear({ force: true })
+            .type(DataLakeUtils.makeTimeString(date), { force: true });
+    }
+
+    public static clickSetTime() {
+        cy.get('.owl-dt-container-buttons > button:nth-child(2)').click();
+    }
+
+    public static makeTimeString(date: Date) {
+        return date.toLocaleString('en-US', {
+            month: 'numeric',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+        });
+    }
+
+    public static getFutureDate() {
+        const currentDate = new Date();
+        currentDate.setMonth(currentDate.getMonth() + 1);
+
+        return currentDate;
     }
 }

--- a/ui/cypress/tests/datalake/widgets/table.ts
+++ b/ui/cypress/tests/datalake/widgets/table.ts
@@ -46,7 +46,7 @@ describe('Test Table View in Data Explorer', () => {
 
         DataLakeUtils.selectTimeRange(
             new Date(2020, 10, 20, 22, 44),
-            new Date(2021, 10, 20, 22, 44),
+            DataLakeUtils.getFutureDate(),
         );
 
         cy.dataCy('data-explorer-table-row', { timeout: 10000 }).should(


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

Some data explorer cypress e2e tests used a static date value (May 30th) in the time selection widget, causing some tests to fail from today on ;-)
The PR now uses a future date and properly clicks on the time selection fields in the data explorer.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
