### PR TITLE
#1374: Convenient columns query parameter for data lake measure

### DIFF
--- a/streampipes-client-python/tests/endpoint/test_data_lake_measure.py
+++ b/streampipes-client-python/tests/endpoint/test_data_lake_measure.py
@@ -17,11 +17,14 @@
 
 from datetime import datetime
 from unittest import TestCase
-from streampipes.endpoint.api.data_lake_measure import DataLakeMeasureEndpoint, StreamPipesQueryValidationError
+
+from streampipes.endpoint.api.data_lake_measure import (
+    DataLakeMeasureEndpoint,
+    StreamPipesQueryValidationError,
+)
 
 
 class TestMeasurementGetQueryConfig(TestCase):
-
     def test_default(self):
         config_dict = {}
         measurement_config = DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
@@ -30,9 +33,7 @@ class TestMeasurementGetQueryConfig(TestCase):
         self.assertEqual("?limit=1000", result)
 
     def test_additional_param_given(self):
-        config_dict = {
-            "columns": "time,value_25"
-        }
+        config_dict = {"columns": ["time", "value_25"]}
 
         measurement_config = DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
         result = measurement_config.build_query_string()
@@ -40,17 +41,13 @@ class TestMeasurementGetQueryConfig(TestCase):
         self.assertEqual("?columns=time,value_25&limit=1000", result)
 
     def test_extra_param(self):
-        config_dict = {
-            "foo": "bar"
-        }
+        config_dict = {"foo": "bar"}
 
         with self.assertRaises(StreamPipesQueryValidationError):
             DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
 
     def test_alias_as_query_param(self):
-        config_dict = {
-            "page_no": 5
-        }
+        config_dict = {"page_no": 5}
 
         measurement_config = DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
         result = measurement_config.build_query_string()
@@ -60,10 +57,7 @@ class TestMeasurementGetQueryConfig(TestCase):
     def test_datetime_validation(self):
         now = datetime.utcnow()
 
-        config_dict = {
-            "start_date": now,
-            "end_date": now
-        }
+        config_dict = {"start_date": now, "end_date": now}
         measurement_config = DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
         result = measurement_config.build_query_string()
 
@@ -73,49 +67,66 @@ class TestMeasurementGetQueryConfig(TestCase):
         self.assertEqual(expected, result)
 
     def test_datetime_validation_no_datetime(self):
-        config_dict = {
-            "start_date": "test"
-        }
+        config_dict = {"start_date": "test"}
 
         with self.assertRaises(StreamPipesQueryValidationError):
             DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict)
 
     def test_columns_validation(self):
-        config_dict_one_col = {
-            "columns": "col1"
-        }
-        config_dict_mul_col = {
-            "columns": "col1,col2,col3"
-        }
-        config_dict_semicolon = {
-            "columns": "col1;col2"
-        }
-        config_dict_whitespace_ending = {
-            "columns": "col1 "
-        }
+        # Column parameter validation tests:
 
-        self.assertEqual("?columns=col1&limit=1000", DataLakeMeasureEndpoint._validate_query_params(
-            query_params=config_dict_one_col).build_query_string())
-        self.assertEqual("?columns=col1,col2,col3&limit=1000", DataLakeMeasureEndpoint._validate_query_params(
-            query_params=config_dict_mul_col).build_query_string())
+        # 1. Valid column parameter values
+        config_dict_one_col = {"columns": ["col1"]}
+        config_dict_mul_col = {"columns": ["col1", "col2", "col3"]}
+        config_dict_default_value = {"columns": None}
+
+        # 2. Invalid column parameter values
+        config_dict_whitespace_ending = {"columns": ["col1 "]}
+        config_dict_semicolon = {"columns": "col1;col2"}
+        config_dict_empty_list = {"columns": []}
+        config_dict_string = {"columns": "colstring"}
+        config_dict_integer = {"columns": 1}
+        config_dict_tuple = {"columns": ("col1", "col2")}
+        config_dict_list_with_non_strings = {"columns": ["col1", "col2", 12, ["co3"]]}
+        config_dict_list_with_elems_containing_invalid_chars = {"columns": ["col1", "col2", "col,3", "col_4", "col 5"]}
+
+        self.assertEqual(
+            "?columns=col1&limit=1000",
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_one_col).build_query_string(),
+        )
+        self.assertEqual(
+            "?columns=col1,col2,col3&limit=1000",
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_mul_col).build_query_string(),
+        )
+        self.assertEqual(
+            "?limit=1000",
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_default_value).build_query_string(),
+        )
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_whitespace_ending)
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_empty_list)
         with self.assertRaises(StreamPipesQueryValidationError):
             DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_semicolon)
         with self.assertRaises(StreamPipesQueryValidationError):
-            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_whitespace_ending)
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_string)
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_integer)
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_tuple)
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_list_with_non_strings)
+        with self.assertRaises(StreamPipesQueryValidationError):
+            DataLakeMeasureEndpoint._validate_query_params(
+                query_params=config_dict_list_with_elems_containing_invalid_chars
+            )
 
     def test_minium_parameter_values(self):
-        config_dict_happy_path = {
-            "limit": 15,
-            "page_no": 3
-        }
+        config_dict_happy_path = {"limit": 15, "page_no": 3}
 
-        config_dict_limit_too_low = {
-            "limit": 0
-        }
+        config_dict_limit_too_low = {"limit": 0}
 
-        config_dict_page_no_too_low = {
-            "page_no": -2
-        }
+        config_dict_page_no_too_low = {"page_no": -2}
 
         measurement_config_happy = DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_happy_path)
         result_happy = measurement_config_happy.build_query_string()
@@ -129,10 +140,7 @@ class TestMeasurementGetQueryConfig(TestCase):
             DataLakeMeasureEndpoint._validate_query_params(query_params=config_dict_page_no_too_low)
 
     def test_literal_validation(self):
-
-        config_invalid_order = {
-            "order": "UP"
-        }
+        config_invalid_order = {"order": "UP"}
 
         with self.assertRaises(StreamPipesQueryValidationError):
             DataLakeMeasureEndpoint._validate_query_params(query_params=config_invalid_order)


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
resolves #1374 

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): yes

PR introduces (a) deprecation(s): no

## Breaking change

The parameter `columns` when querying data lake measures expects now a list of strings:
```python
client.dataLakeMeasureApi.get(identifier="flow-rate", columns=["mass_flow", "temperature"])
```

Single strings are no longer allowed.
