### PR TITLE
Remove sources-vehicle-simulator from cli-installer full env.

### DIFF
--- a/installer/cli/environments/full
+++ b/installer/cli/environments/full
@@ -26,6 +26,5 @@ zookeeper
 kafka
 influxdb
 sources-watertank-simulator
-sources-vehicle-simulator
 pipeline-elements-all-jvm
 pipeline-elements-all-flink


### PR DESCRIPTION
As discoussed in #1597  sources-vehicle-simulator should be remove from default installers.

<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  

### Purpose
Not supported containers removed from installer environment profile.

### Remarks

PR introduces a breaking change: no

PR introduces a deprecation: no
