### PR TITLE
Reordering Parameters in the PostgreSQL Database Sink Connector

### DIFF
--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/postgresql/PostgreSqlSink.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/postgresql/PostgreSqlSink.java
@@ -87,9 +87,9 @@ public class PostgreSqlSink extends StreamPipesDataSink {
         hostname,
         port,
         dbName,
-        tableName,
         user,
-        password,
+        password,      
+        tableName,
         sslSelection.equals(SSL_ENABLED));
 
     this.postgreSql = new PostgreSql();


### PR DESCRIPTION
### Purpose

This PR resolves an issue found in onInvocation() function, responsible for creating the parameters to establish the connection to the PostgreSQL database in the project. The error occurred when parameters were provided in the incorrect order, leading to connection failures.

### Remarks

Reordered the parameters to ensure the correct sequence is followed.

The correct sequence is: https://github.com/apache/streampipes/blob/dev/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/postgresql/PostgreSqlParameters.java#L26

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
