### PR TITLE
Use os.environ dictionary to set environment variables.

### DIFF
--- a/streampipes-client-python/docs/tutorials/1-introduction-to-streampipes-python-client.ipynb
+++ b/streampipes-client-python/docs/tutorials/1-introduction-to-streampipes-python-client.ipynb
@@ -170,8 +170,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "%export SP_USERNAME=\"<USERNAME>\"\n",
-    "%export SP_API_KEY=\"<API-KEY>\""
+    "import os\n",
+    "os.environ[\"SP_USERNAME\"] = \"admin@streampipes.apache.org\"\n",
+    "os.environ[\"SP_API_KEY\"] = \"XXX\"\n"
    ],
    "metadata": {
     "collapsed": false


### PR DESCRIPTION


<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  

### Purpose
`%export ENVIRONMENT_VARIABLE ` could led to "UsageError: Line magic function `%export` not found." error.

`os.environ` dictionary seems to be more generic and reuses the approach from other StreamPipes Python tutorials.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
