### PR TITLE
#2151 & #2223: Implement E2E tests for enhanced adapter deletion and Extend reset REST endpoint to remove users

### DIFF
--- a/streampipes-rest/src/main/java/org/apache/streampipes/rest/impl/ResetResource.java
+++ b/streampipes-rest/src/main/java/org/apache/streampipes/rest/impl/ResetResource.java
@@ -18,8 +18,9 @@
 
 package org.apache.streampipes.rest.impl;
 
+import org.apache.streampipes.model.client.user.Principal;
+import org.apache.streampipes.model.client.user.PrincipalType;
 import org.apache.streampipes.model.message.Notifications;
-import org.apache.streampipes.model.message.SuccessMessage;
 import org.apache.streampipes.rest.ResetManagement;
 import org.apache.streampipes.rest.core.base.impl.AbstractAuthGuardedRestResource;
 import org.apache.streampipes.rest.shared.annotation.JacksonSerialized;
@@ -34,6 +35,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.util.ArrayList;
+
 @Path("/v2/reset")
 public class ResetResource extends AbstractAuthGuardedRestResource {
   private static final Logger logger = LoggerFactory.getLogger(ResetResource.class);
@@ -44,7 +47,17 @@ public class ResetResource extends AbstractAuthGuardedRestResource {
   @Operation(summary = "Resets StreamPipes instance")
   public Response reset() {
     ResetManagement.reset(getAuthenticatedUsername());
-    SuccessMessage message = Notifications.success("Reset of system successfully performed");
+    var userStorage = getUserStorage();
+    // Delete all users other than admin and their resources
+    var allUsers = new ArrayList<Principal>(userStorage.getAllUsers());
+    for (var user : allUsers) {
+      if (user.getPrincipalType() == PrincipalType.USER_ACCOUNT
+          && !user.getPrincipalId().equals(getAuthenticatedUserSid())) {
+        ResetManagement.reset(user.getUsername());
+        userStorage.deleteUser(user.getPrincipalId());
+      }
+    }
+    var message = Notifications.success("Reset of system successfully performed");
     return ok(message);
   }
 

--- a/streampipes-rest/src/main/java/org/apache/streampipes/rest/impl/ResetResource.java
+++ b/streampipes-rest/src/main/java/org/apache/streampipes/rest/impl/ResetResource.java
@@ -48,7 +48,7 @@ public class ResetResource extends AbstractAuthGuardedRestResource {
   public Response reset() {
     ResetManagement.reset(getAuthenticatedUsername());
     var userStorage = getUserStorage();
-    // Delete all users other than admin and their resources
+    // Delete all users other than current user (admin) and their resources
     var allUsers = new ArrayList<Principal>(userStorage.getAllUsers());
     for (var user : allUsers) {
       if (user.getPrincipalType() == PrincipalType.USER_ACCOUNT

--- a/ui/cypress/support/utils/UserUtils.ts
+++ b/ui/cypress/support/utils/UserUtils.ts
@@ -27,6 +27,15 @@ export class UserUtils {
         .addRole(UserRole.ROLE_ADMIN)
         .build();
 
+    public static adapterAndPipelineAdminUser = UserBuilder.create(
+        'anpadmin@streampipes.apache.org',
+    )
+        .setName('anpadmin')
+        .setPassword('anpadmin')
+        .addRole(UserRole.ROLE_PIPELINE_ADMIN)
+        .addRole(UserRole.ROLE_CONNECT_ADMIN)
+        .build();
+
     public static goToUserConfiguration() {
         cy.visit('#/configuration/security');
     }
@@ -42,9 +51,11 @@ export class UserUtils {
         cy.dataCy('new-user-password-repeat').type(user.password);
 
         // Set role
-        cy.dataCy('role-' + user.role[0])
-            .children()
-            .click();
+        for (var i = 0; i < user.role.length; i++) {
+            cy.dataCy('role-' + user.role[i])
+                .children()
+                .click();
+        }
         cy.dataCy('new-user-enabled').children().click();
 
         // Store

--- a/ui/cypress/support/utils/connect/ConnectUtils.ts
+++ b/ui/cypress/support/utils/connect/ConnectUtils.ts
@@ -228,6 +228,8 @@ export class ConnectUtils {
         this.checkAdapterAndAssociatedPipelinesDeleted();
     }
 
+    // NOTE: this function will leave the adapter and associated pipelines running,
+    // please make sure to clean up after calling this function
     public static deleteAdapterAndAssociatedPipelinesPermissionDenied() {
         // Associated pipelines not owned by the user (unless admin) should not be deleted during adapter deletion
         this.goToConnect();
@@ -244,39 +246,14 @@ export class ConnectUtils {
         }).should('be.visible');
         cy.get('.sp-dialog-actions').click();
         this.checkAdapterNotDeleted();
-
-        // Switch back to admin to clean up
-        cy.switchUser(UserUtils.adminUser);
-        this.goToConnect();
-        cy.dataCy('delete-adapter', { timeout: 10000 }).should(
-            'have.length',
-            1,
-        );
-        this.clickDelete();
-        cy.dataCy('delete-adapter-and-associated-pipelines-confirmation', {
-            timeout: 10000,
-        }).should('be.visible');
-        cy.dataCy(
-            'delete-adapter-and-associated-pipelines-confirmation',
-        ).click();
-        cy.dataCy('adapter-deletion-in-progress', { timeout: 10000 }).should(
-            'be.visible',
-        );
-        this.checkAdapterAndAssociatedPipelinesDeleted();
-        UserUtils.deleteUser(UserUtils.adapterAndPipelineAdminUser);
-        // Verify that the user is removed
-        cy.dataCy('user-accounts-table-row', { timeout: 10000 }).should(
-            'have.length',
-            1,
-        );
     }
 
-    private static clickDelete() {
+    public static clickDelete() {
         cy.dataCy('delete-adapter').click();
         cy.dataCy('delete-adapter-confirmation').click();
     }
 
-    private static checkAdapterNotDeleted() {
+    public static checkAdapterNotDeleted() {
         this.goToConnect();
         cy.dataCy('delete-adapter', { timeout: 20000 }).should(
             'have.length',
@@ -284,7 +261,7 @@ export class ConnectUtils {
         );
     }
 
-    private static checkAdapterAndAssociatedPipelinesDeleted() {
+    public static checkAdapterAndAssociatedPipelinesDeleted() {
         this.goToConnect();
         cy.dataCy('delete-adapter', { timeout: 20000 }).should(
             'have.length',

--- a/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
@@ -48,7 +48,7 @@ const pipelineInput = PipelineBuilder.create('Pipeline Test')
 describe('Test Enhanced Adapter Deletion', () => {
     // In the beginning, create the non-admin user
     before(() => {
-        cy.login(UserUtils.adminUser);
+        cy.initStreamPipesTest();
         UserUtils.addUser(UserUtils.adapterAndPipelineAdminUser);
         cy.logout();
     });

--- a/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { AdapterBuilder } from '../../support/builder/AdapterBuilder';
+import { ConnectUtils } from '../../support/utils/connect/ConnectUtils';
+import { PipelineBuilder } from '../../support/builder/PipelineBuilder';
+import { PipelineElementBuilder } from '../../support/builder/PipelineElementBuilder';
+import { UserUtils } from '../../support/utils/UserUtils';
+import { PipelineUtils } from '../../support/utils/PipelineUtils';
+
+const adapterName = 'simulator';
+
+const adapterInput = AdapterBuilder.create('Machine_Data_Simulator')
+    .setName(adapterName)
+    .addInput('input', 'wait-time-ms', '1000')
+    .build();
+
+const pipelineInput = PipelineBuilder.create('Pipeline Test')
+    .addSource(adapterName)
+    .addProcessingElement(
+        PipelineElementBuilder.create('field_renamer')
+            .addInput('drop-down', 'convert-property', 'timestamp')
+            .addInput('input', 'field-name', 't')
+            .build(),
+    )
+    .addSink(
+        PipelineElementBuilder.create('data_lake')
+            .addInput('input', 'db_measurement', 'demo')
+            .build(),
+    )
+    .build();
+
+describe('Test Enhanced Adapter Deletion', () => {
+    // In the beginning, create the non-admin user
+    before(() => {
+        cy.login(UserUtils.adminUser);
+        UserUtils.addUser(UserUtils.adapterAndPipelineAdminUser);
+        cy.logout();
+    });
+
+    // After the last test, let admin user clean up (delete the adapter, associated pipelines, and the non-admin user)
+    after(() => {
+        cy.switchUser(UserUtils.adminUser);
+        ConnectUtils.goToConnect();
+        cy.dataCy('delete-adapter', { timeout: 10000 }).should(
+            'have.length',
+            1,
+        );
+        ConnectUtils.clickDelete();
+        cy.dataCy('delete-adapter-and-associated-pipelines-confirmation', {
+            timeout: 10000,
+        }).should('be.visible');
+        cy.dataCy(
+            'delete-adapter-and-associated-pipelines-confirmation',
+        ).click();
+        cy.dataCy('adapter-deletion-in-progress', { timeout: 10000 }).should(
+            'be.visible',
+        );
+        ConnectUtils.checkAdapterAndAssociatedPipelinesDeleted();
+        UserUtils.deleteUser(UserUtils.adapterAndPipelineAdminUser);
+        // Verify that the user is removed
+        cy.dataCy('user-accounts-table-row', { timeout: 10000 }).should(
+            'have.length',
+            1,
+        );
+    });
+
+    beforeEach('Setup Test', () => {
+        cy.visit('#/login');
+        cy.dataCy('login-email').type(
+            UserUtils.adapterAndPipelineAdminUser.email,
+        );
+        cy.dataCy('login-password').type(
+            UserUtils.adapterAndPipelineAdminUser.password,
+        );
+        cy.dataCy('login-button').click();
+        cy.wait(1000);
+    });
+
+    it('Test Delete Adapter and Associated Pipelines', () => {
+        ConnectUtils.testAdapter(adapterInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        ConnectUtils.deleteAdapterAndAssociatedPipelines();
+    });
+
+    it('Test Admin Should Be Able to Delete Adapter and Not Owned Associated Pipelines', () => {
+        // Let the user create the adapter and the pipeline
+        ConnectUtils.testAdapter(adapterInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        // Then let the admin delete them
+        cy.switchUser(UserUtils.adminUser);
+        ConnectUtils.deleteAdapterAndAssociatedPipelines(true);
+    });
+
+    it('Test Delete Adapter and Associated Pipelines Permission Denied', () => {
+        // Let the admin create the adapter and the pipeline
+        cy.switchUser(UserUtils.adminUser);
+        ConnectUtils.testAdapter(adapterInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        PipelineUtils.addPipeline(pipelineInput);
+        // Then the user shouldn't be able to delete them
+        cy.switchUser(UserUtils.adapterAndPipelineAdminUser);
+        ConnectUtils.deleteAdapterAndAssociatedPipelinesPermissionDenied();
+    });
+});

--- a/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/enhancedDeleteAdapter.smoke.spec.ts
@@ -53,33 +53,6 @@ describe('Test Enhanced Adapter Deletion', () => {
         cy.logout();
     });
 
-    // After the last test, let admin user clean up (delete the adapter, associated pipelines, and the non-admin user)
-    after(() => {
-        cy.switchUser(UserUtils.adminUser);
-        ConnectUtils.goToConnect();
-        cy.dataCy('delete-adapter', { timeout: 10000 }).should(
-            'have.length',
-            1,
-        );
-        ConnectUtils.clickDelete();
-        cy.dataCy('delete-adapter-and-associated-pipelines-confirmation', {
-            timeout: 10000,
-        }).should('be.visible');
-        cy.dataCy(
-            'delete-adapter-and-associated-pipelines-confirmation',
-        ).click();
-        cy.dataCy('adapter-deletion-in-progress', { timeout: 10000 }).should(
-            'be.visible',
-        );
-        ConnectUtils.checkAdapterAndAssociatedPipelinesDeleted();
-        UserUtils.deleteUser(UserUtils.adapterAndPipelineAdminUser);
-        // Verify that the user is removed
-        cy.dataCy('user-accounts-table-row', { timeout: 10000 }).should(
-            'have.length',
-            1,
-        );
-    });
-
     beforeEach('Setup Test', () => {
         cy.visit('#/login');
         cy.dataCy('login-email').type(

--- a/ui/cypress/tests/adapter/machineDataSimulator.smoke.spec.ts
+++ b/ui/cypress/tests/adapter/machineDataSimulator.smoke.spec.ts
@@ -18,72 +18,19 @@
 
 import { ConnectUtils } from '../../support/utils/connect/ConnectUtils';
 import { AdapterBuilder } from '../../support/builder/AdapterBuilder';
-import { PipelineBuilder } from '../../support/builder/PipelineBuilder';
-import { PipelineElementBuilder } from '../../support/builder/PipelineElementBuilder';
-import { PipelineUtils } from '../../support/utils/PipelineUtils';
-import { UserUtils } from '../../support/utils/UserUtils';
-
-const adapterName = 'simulator';
 
 describe('Test Machine Data Simulator Adapter', () => {
     beforeEach('Setup Test', () => {
         cy.initStreamPipesTest();
     });
 
-    const adapterInput = AdapterBuilder.create('Machine_Data_Simulator')
-        .setName(adapterName)
-        .addInput('input', 'wait-time-ms', '1000')
-        .build();
+    it('Perform Test', () => {
+        const adapterInput = AdapterBuilder.create('Machine_Data_Simulator')
+            .setName('Machine Data Simulator Test')
+            .addInput('input', 'wait-time-ms', '1000')
+            .build();
 
-    it('Test Basic Delete Adapter', () => {
         ConnectUtils.testAdapter(adapterInput);
         ConnectUtils.deleteAdapter();
-    });
-
-    const pipelineInput = PipelineBuilder.create('Pipeline Test')
-        .addSource(adapterName)
-        .addProcessingElement(
-            PipelineElementBuilder.create('field_renamer')
-                .addInput('drop-down', 'convert-property', 'timestamp')
-                .addInput('input', 'field-name', 't')
-                .build(),
-        )
-        .addSink(
-            PipelineElementBuilder.create('data_lake')
-                .addInput('input', 'db_measurement', 'demo')
-                .build(),
-        )
-        .build();
-
-    it('Test Delete Adapter and Associated Pipelines', () => {
-        UserUtils.addUser(UserUtils.adapterAndPipelineAdminUser);
-        cy.switchUser(UserUtils.adapterAndPipelineAdminUser);
-        ConnectUtils.testAdapter(adapterInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        ConnectUtils.deleteAdapterAndAssociatedPipelines();
-    });
-
-    it('Test Admin Should Be Able to Delete Adapter and Not Owned Associated Pipelines', () => {
-        // Let the user create the adapter and the pipeline
-        // For some reason, I have to first go to a page before switching user
-        UserUtils.goToUserConfiguration();
-        cy.switchUser(UserUtils.adapterAndPipelineAdminUser);
-        ConnectUtils.testAdapter(adapterInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        // Then let the admin delete them
-        cy.switchUser(UserUtils.adminUser);
-        ConnectUtils.deleteAdapterAndAssociatedPipelines(true);
-    });
-
-    it('Test Delete Adapter and Associated Pipelines Permission Denied', () => {
-        // Let the admin create the adapter and the pipeline
-        ConnectUtils.testAdapter(adapterInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        PipelineUtils.addPipeline(pipelineInput);
-        // Then the user shouldn't be able to delete them
-        cy.switchUser(UserUtils.adapterAndPipelineAdminUser);
-        ConnectUtils.deleteAdapterAndAssociatedPipelinesPermissionDenied();
     });
 });

--- a/ui/src/app/connect/dialog/delete-adapter-dialog/delete-adapter-dialog.component.html
+++ b/ui/src/app/connect/dialog/delete-adapter-dialog/delete-adapter-dialog.component.html
@@ -67,6 +67,7 @@
             fxLayoutAlign="center center"
             fxLayout="column"
             style="width: 100%"
+            data-cy="adapter-deletion-permission-denied"
         >
             <b>
                 <h4>


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
See #2151 

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no

Added E2E tests for these 3 cases:

- An adapter and >1 pipelines are created by a non-admin user, the non-admin user should be able to delete the adapter and associated pipelines.
- A public adapter and >1 pipelines are created by a non-admin user, the admin should be able to delete the adapter and associated pipelines.
- A public adapter and >1 pipelines are created by admin (or any other users), the non-admin user should not be able to delete the adapter and the associated pipelines. After checking this, switch to admin's account to clean up (delete adapter, associated pipelines, non-admin user).

NOTE: I modified the logic of roles in `addUser()` of `UserUtil.ts` because I need the non-admin user to have both Connect and Pipeline admin privileges. I have run cypress tests locally and they all passed but I am not sure if this change will affect other tests in CI. For some reason the original logic is only taking the first role out of all roles.

Also sorry for closing my previous PR because I force pushed it to revert changes and separate my PR to 2 PRs 😅==
