### PR TITLE
refactor: remove deprecated method `fromResources`

### DIFF
--- a/streampipes-sdk/src/main/java/org/apache/streampipes/sdk/helpers/Labels.java
+++ b/streampipes-sdk/src/main/java/org/apache/streampipes/sdk/helpers/Labels.java
@@ -20,22 +20,16 @@ package org.apache.streampipes.sdk.helpers;
 
 import org.apache.streampipes.commons.resources.Resources;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
 
 public class Labels {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Labels.class);
-
   /**
    * @deprecated Externalize labels by using
    * {@link org.apache.streampipes.sdk.builder.AbstractProcessingElementBuilder#withLocales(Locales...)}
    * to ease future support for multiple languages.
-   *
    * Creates a new label with internalId, label and description. Fully-configured labels are required by static
    * properties and are mandatory for event properties.
    *
@@ -47,22 +41,6 @@ public class Labels {
   @Deprecated(since = "0.90.0", forRemoval = true)
   public static Label from(String internalId, String label, String description) {
     return new Label(internalId, label, description);
-  }
-
-  /**
-   * @deprecated Externalize labels by using
-   * {@link org.apache.streampipes.sdk.builder.AbstractProcessingElementBuilder#withLocales(Locales...)}
-   * to ease future support for multiple languages.
-   */
-  @Deprecated(since = "0.90.0", forRemoval = true)
-  public static Label fromResources(String resourceIdentifier, String resourceName) {
-    try {
-      return new Label(resourceName, findTitleLabel(resourceIdentifier, resourceName),
-          findDescriptionLabel(resourceIdentifier, resourceName));
-    } catch (Exception e) {
-      LOG.error("Could not find resource " + resourceIdentifier);
-      return new Label(resourceName, "", "");
-    }
   }
 
   /**


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
This PR removes the method `fromResources` of the `Labels` class that has been marked for deprecated since `0.90.0`.

### Deprecations
The following methods have been deprecated since `0.90.0` and are now removed:
- Label fromResources(String resourceIdentifier, String resourceName)

This can be replaced by working with the `withLocales()` method of processing element builders.


### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): <yes/no>

PR introduces (a) deprecation(s): <yes/no>
