### PR TITLE
fix: filter for running adapter instances in adapter health check

### DIFF
--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/health/AdapterHealthCheck.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/health/AdapterHealthCheck.java
@@ -24,7 +24,6 @@ import org.apache.streampipes.connect.management.management.WorkerRestClient;
 import org.apache.streampipes.connect.management.util.WorkerPaths;
 import org.apache.streampipes.model.connect.adapter.AdapterDescription;
 import org.apache.streampipes.storage.api.IAdapterStorage;
-import org.apache.streampipes.storage.couchdb.CouchDbStorageManager;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +40,10 @@ public class AdapterHealthCheck implements Runnable {
   private final IAdapterStorage adapterStorage;
   private final AdapterMasterManagement adapterMasterManagement;
 
-  public AdapterHealthCheck() {
-    this.adapterStorage = CouchDbStorageManager.INSTANCE.getAdapterInstanceStorage();
-    this.adapterMasterManagement = new AdapterMasterManagement();
-  }
-
-  public AdapterHealthCheck(IAdapterStorage adapterStorage,
-                            AdapterMasterManagement adapterMasterManagement) {
+  public AdapterHealthCheck(
+      IAdapterStorage adapterStorage,
+      AdapterMasterManagement adapterMasterManagement
+  ) {
     this.adapterStorage = adapterStorage;
     this.adapterMasterManagement = adapterMasterManagement;
   }
@@ -82,8 +78,14 @@ public class AdapterHealthCheck implements Runnable {
   public Map<String, AdapterDescription> getAllRunningInstancesAdapterDescriptions() {
     Map<String, AdapterDescription> result = new HashMap<>();
     List<AdapterDescription> allRunningInstancesAdapterDescription = this.adapterStorage.getAllAdapters();
-    allRunningInstancesAdapterDescription.forEach(adapterDescription ->
-        result.put(adapterDescription.getElementId(), adapterDescription));
+    allRunningInstancesAdapterDescription
+        .stream()
+        .filter(AdapterDescription::isRunning)
+        .forEach(adapterDescription ->
+                     result.put(
+                         adapterDescription.getElementId(),
+                         adapterDescription
+                     ));
 
     return result;
   }

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/WorkerAdministrationManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/WorkerAdministrationManagement.java
@@ -28,6 +28,7 @@ import org.apache.streampipes.resource.management.PermissionResourceManager;
 import org.apache.streampipes.resource.management.SpResourceManager;
 import org.apache.streampipes.storage.api.IAdapterStorage;
 import org.apache.streampipes.storage.couchdb.CouchDbStorageManager;
+import org.apache.streampipes.storage.management.StorageDispatcher;
 import org.apache.streampipes.svcdiscovery.api.model.SpServiceUrlProvider;
 
 import org.slf4j.Logger;
@@ -47,7 +48,11 @@ public class WorkerAdministrationManagement {
   private final AdapterHealthCheck adapterHealthCheck;
 
   public WorkerAdministrationManagement() {
-    this.adapterHealthCheck = new AdapterHealthCheck();
+    this.adapterHealthCheck = new AdapterHealthCheck(
+        StorageDispatcher.INSTANCE.getNoSqlStore()
+                                  .getAdapterInstanceStorage(),
+        new AdapterMasterManagement()
+    );
     this.adapterDescriptionStorage = CouchDbStorageManager.INSTANCE.getAdapterDescriptionStorage();
   }
 

--- a/streampipes-connect-management/src/test/java/org/apache/streampipes/connect/management/health/AdapterHealthCheckTest.java
+++ b/streampipes-connect-management/src/test/java/org/apache/streampipes/connect/management/health/AdapterHealthCheckTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.connect.management.health;
+
+import org.apache.streampipes.connect.management.management.AdapterMasterManagement;
+import org.apache.streampipes.model.connect.adapter.AdapterDescription;
+import org.apache.streampipes.storage.api.IAdapterStorage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AdapterHealthCheckTest {
+
+  private IAdapterStorage adapterInstanceStorageMock;
+
+  @Before
+  public void setUp() {
+    adapterInstanceStorageMock = mock(IAdapterStorage.class);
+  }
+
+  @Test
+  public void getAllRunningInstancesAdapterDescriptionsEmpty() {
+    when(adapterInstanceStorageMock.getAllAdapters()).thenReturn(List.of());
+
+    var healthCheck = new AdapterHealthCheck(adapterInstanceStorageMock, new AdapterMasterManagement());
+    var result = healthCheck.getAllRunningInstancesAdapterDescriptions();
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void getAllRunningInstancesAdapterDescriptionsMixed() {
+
+    var stoppedAdapter = new AdapterDescription();
+    stoppedAdapter.setElementId("stopped-adapter");
+    stoppedAdapter.setRunning(false);
+
+    var runningAdapter = new AdapterDescription();
+    runningAdapter.setElementId("running-adapter");
+    runningAdapter.setRunning(true);
+
+    when(adapterInstanceStorageMock.getAllAdapters()).thenReturn(List.of(stoppedAdapter, runningAdapter));
+
+    var healthCheck = new AdapterHealthCheck(adapterInstanceStorageMock, new AdapterMasterManagement());
+    var result = healthCheck.getAllRunningInstancesAdapterDescriptions();
+
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("running-adapter"));
+    assertEquals(runningAdapter, result.get("running-adapter"));
+
+  }
+
+}

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/StreamPipesCoreApplication.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/StreamPipesCoreApplication.java
@@ -19,6 +19,7 @@ package org.apache.streampipes.service.core;
 
 import org.apache.streampipes.commons.environment.Environments;
 import org.apache.streampipes.connect.management.health.AdapterHealthCheck;
+import org.apache.streampipes.connect.management.management.AdapterMasterManagement;
 import org.apache.streampipes.manager.health.CoreInitialInstallationProgress;
 import org.apache.streampipes.manager.health.CoreServiceStatusManager;
 import org.apache.streampipes.manager.health.PipelineHealthCheck;
@@ -139,7 +140,10 @@ public class StreamPipesCoreApplication extends StreamPipesServiceBase {
         List.of(
             new ServiceHealthCheck(),
             new PipelineHealthCheck(),
-            new AdapterHealthCheck())
+            new AdapterHealthCheck(
+                StorageDispatcher.INSTANCE.getNoSqlStore().getAdapterInstanceStorage(),
+                new AdapterMasterManagement()
+            ))
     );
 
     var logFetchInterval = env.getLogFetchIntervalInMillis().getValueOrDefault();


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
Within the adapter health check, the method `getAllRunningInstancesAdapterDescriptions()` does not filter for running instances albeit the name indicates it.
This PR fixes the missing filter.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
