### PR TITLE
[#2473] Nginx configuration migraton to version 0.93.0+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     depends_on:
       - couchdb
       - backend
+    volumes:
+      - nginx:/etc/nginx/
     logging: *default-logging
     networks:
       spnet:
@@ -141,6 +143,7 @@ volumes:
   influxdb:
   influxdb2:
   backend:
+  nginx:
 
 networks:
   spnet:

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,6 +17,13 @@ FROM nginx:mainline-alpine3.18
 
 COPY dist/streampipes/ui/ /usr/share/nginx/html/
 
+#Store a copy to have a version if the other is hidden in the volume. Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
+RUN mkdir -p /etc/opt/nginx/
+RUN chown -R nginx:nginx /etc/opt/nginx/
+COPY nginx_config/default.conf.template /etc/opt/nginx/default.conf.template
+RUN chown -R nginx:nginx  /etc/opt/nginx/default.conf.template
+
+
 
 RUN chown -R nginx:nginx /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html && \
         chown -R nginx:nginx /var/cache/nginx && \

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -19,11 +19,22 @@ if [ ! -z "$NGINX_SSL" ] && [ "$NGINX_SSL" = "true" ]; then
     rm /etc/nginx/conf.d/default.conf
     ln -s /app/nginx-confs/ssl.conf /etc/nginx/conf.d/default.conf
 elif [ ! -z "$SP_HTTP_SERVER_ADAPTER_ENDPOINT" ]; then
-    DEFAULT_CONF_BACKUP="/etc/nginx/conf.d/default.conf_$(date +%s).bak"
-    echo "Create backup of old configuration $DEFAULT_CONF_BACKUP"
-    cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
 
-    rm /etc/nginx/conf.d/default.conf
+    if [ ! -f /etc/nginx/conf.d/default.conf ]
+    then
+        DEFAULT_CONF_BACKUP="/etc/nginx/conf.d/default.conf_$(date +%s).bak"
+        echo "Create backup of old configuration $DEFAULT_CONF_BACKUP"
+        cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
+    fi
+
+    # Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
+    if [ ! -f /etc/nginx/conf.d/default.conf.template ]
+    then
+        echo "Migrate to new nginx template"
+        cp /etc/opt/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
+    fi
+
+    rm  -f /etc/nginx/conf.d/default.conf
     envsubst '\$SP_HTTP_SERVER_ADAPTER_ENDPOINT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi
 


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
### Purpose
Fix Nginx startup problems because of missing configuration in case of a auto generated configuration.
 Copy the missing template file to the correct location from a second locaton (/etc/opt/nginx/)

### Remarks
Could be removed in future versions.

PR introduces a breaking change: no
PR introduces a deprecation: no

fixes  #2473
