### PR TITLE
Add kafka oci image to cli env minimal

### DIFF
--- a/installer/cli/environments/minimal
+++ b/installer/cli/environments/minimal
@@ -20,3 +20,5 @@ couchdb
 influxdb
 mosquitto
 extensions-all-jvm
+zookeeper
+kafka


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  

### Purpose

Currently, no messaging protocol implementation is configured in this environment.
As Kafka is currently the default protocol, Kafka and Zookeeper images are added to the configuration.

PR introduces (a) breaking change(s): no
PR introduces (a) deprecation(s): no
