### PR TITLE
2312 Extend Notification sinks by silent period

### DIFF
--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/NotificationsExtensionModuleExport.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/NotificationsExtensionModuleExport.java
@@ -23,6 +23,9 @@ import org.apache.streampipes.extensions.api.declarer.IExtensionModuleExport;
 import org.apache.streampipes.extensions.api.migration.IModelMigrator;
 import org.apache.streampipes.extensions.api.pe.IStreamPipesPipelineElement;
 import org.apache.streampipes.sinks.notifications.jvm.email.EmailSink;
+import org.apache.streampipes.sinks.notifications.jvm.migrations.OneSignalSinkMigrationV1;
+import org.apache.streampipes.sinks.notifications.jvm.migrations.SlackNotificationSinkMigrationV1;
+import org.apache.streampipes.sinks.notifications.jvm.migrations.TelegramSinkMigrationV1;
 import org.apache.streampipes.sinks.notifications.jvm.msteams.MSTeamsSink;
 import org.apache.streampipes.sinks.notifications.jvm.onesignal.OneSignalSink;
 import org.apache.streampipes.sinks.notifications.jvm.slack.SlackNotificationSink;
@@ -50,6 +53,10 @@ public class NotificationsExtensionModuleExport implements IExtensionModuleExpor
 
   @Override
   public List<IModelMigrator<?, ?>> migrators() {
-    return Collections.emptyList();
+    return List.of(
+            new OneSignalSinkMigrationV1(),
+            new SlackNotificationSinkMigrationV1(),
+            new TelegramSinkMigrationV1()
+    );
   }
 }

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigrator.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigrator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.sinks.notifications.jvm.migrations;
+
+import org.apache.streampipes.extensions.api.extractor.IDataSinkParameterExtractor;
+import org.apache.streampipes.extensions.api.migration.IDataSinkMigrator;
+import org.apache.streampipes.model.graph.DataSinkInvocation;
+import org.apache.streampipes.model.migration.MigrationResult;
+import org.apache.streampipes.model.staticproperty.FreeTextStaticProperty;
+import org.apache.streampipes.vocabulary.XSD;
+
+import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.DEFAULT_WAITING_TIME_MINUTES;
+import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.KEY_SILENT_PERIOD;
+
+public interface INotificationDataSinkMigrator extends IDataSinkMigrator  {
+  @Override
+  default MigrationResult<DataSinkInvocation> migrate(DataSinkInvocation element,
+                                                      IDataSinkParameterExtractor extractor) throws RuntimeException {
+    var fsp = new FreeTextStaticProperty(KEY_SILENT_PERIOD,
+        "Silent Period [min]",
+        "The minimum number of minutes between two consecutive notifications that are sent",
+        XSD.INTEGER);
+    fsp.setValue(String.valueOf(DEFAULT_WAITING_TIME_MINUTES));
+    element.getStaticProperties().add(fsp);
+
+    return MigrationResult.success(element);
+  }
+}

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/OneSignalSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/OneSignalSinkMigrationV1.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.sinks.notifications.jvm.migrations;
+
+import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
+import org.apache.streampipes.model.migration.ModelMigratorConfig;
+
+public class OneSignalSinkMigrationV1 implements INotificationDataSinkMigrator {
+  @Override
+  public ModelMigratorConfig config() {
+    return new ModelMigratorConfig(
+        "org.apache.streampipes.sinks.notifications.jvm.onesignal",
+        SpServiceTagPrefix.DATA_SINK,
+        0,
+        1
+    );
+  }
+}

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/OneSignalSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/OneSignalSinkMigrationV1.java
@@ -21,14 +21,16 @@ package org.apache.streampipes.sinks.notifications.jvm.migrations;
 import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
 import org.apache.streampipes.model.migration.ModelMigratorConfig;
 
+import static org.apache.streampipes.sinks.notifications.jvm.onesignal.OneSignalSink.ONE_SIGNAL_NOTIFICATION_SINK_ID;
+
 public class OneSignalSinkMigrationV1 implements INotificationDataSinkMigrator {
   @Override
   public ModelMigratorConfig config() {
     return new ModelMigratorConfig(
-        "org.apache.streampipes.sinks.notifications.jvm.onesignal",
-        SpServiceTagPrefix.DATA_SINK,
-        0,
-        1
+      ONE_SIGNAL_NOTIFICATION_SINK_ID,
+      SpServiceTagPrefix.DATA_SINK,
+      0,
+      1
     );
   }
 }

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/SlackNotificationSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/SlackNotificationSinkMigrationV1.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.sinks.notifications.jvm.migrations;
+
+import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
+import org.apache.streampipes.model.migration.ModelMigratorConfig;
+
+public class SlackNotificationSinkMigrationV1 implements INotificationDataSinkMigrator {
+  @Override
+  public ModelMigratorConfig config() {
+    return new ModelMigratorConfig(
+      "org.apache.streampipes.sinks.notifications.jvm.slack",
+      SpServiceTagPrefix.DATA_SINK,
+      0,
+      1
+    );
+  }
+}

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/SlackNotificationSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/SlackNotificationSinkMigrationV1.java
@@ -21,11 +21,13 @@ package org.apache.streampipes.sinks.notifications.jvm.migrations;
 import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
 import org.apache.streampipes.model.migration.ModelMigratorConfig;
 
+import static org.apache.streampipes.sinks.notifications.jvm.slack.SlackNotificationSink.SLACK_NOTIFICATION_SINK_ID;
+
 public class SlackNotificationSinkMigrationV1 implements INotificationDataSinkMigrator {
   @Override
   public ModelMigratorConfig config() {
     return new ModelMigratorConfig(
-      "org.apache.streampipes.sinks.notifications.jvm.slack",
+      SLACK_NOTIFICATION_SINK_ID,
       SpServiceTagPrefix.DATA_SINK,
       0,
       1

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/TelegramSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/TelegramSinkMigrationV1.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.sinks.notifications.jvm.migrations;
+
+import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
+import org.apache.streampipes.model.migration.ModelMigratorConfig;
+
+public class TelegramSinkMigrationV1 implements INotificationDataSinkMigrator {
+  @Override
+  public ModelMigratorConfig config() {
+    return new ModelMigratorConfig(
+      "org.apache.streampipes.sinks.notifications.jvm.telegram",
+      SpServiceTagPrefix.DATA_SINK,
+      0,
+      1
+    );
+  }
+}

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/TelegramSinkMigrationV1.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/migrations/TelegramSinkMigrationV1.java
@@ -21,11 +21,13 @@ package org.apache.streampipes.sinks.notifications.jvm.migrations;
 import org.apache.streampipes.model.extensions.svcdiscovery.SpServiceTagPrefix;
 import org.apache.streampipes.model.migration.ModelMigratorConfig;
 
+import static org.apache.streampipes.sinks.notifications.jvm.telegram.TelegramSink.TELEGRAM_NOTIFICATION_SINK_ID;
+
 public class TelegramSinkMigrationV1 implements INotificationDataSinkMigrator {
   @Override
   public ModelMigratorConfig config() {
     return new ModelMigratorConfig(
-      "org.apache.streampipes.sinks.notifications.jvm.telegram",
+      TELEGRAM_NOTIFICATION_SINK_ID,
       SpServiceTagPrefix.DATA_SINK,
       0,
       1

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
@@ -79,7 +79,7 @@ public class OneSignalSink extends StreamPipesNotificationSink {
   }
 
   @Override
-  public void onNotificationEvent(Event inputEvent) throws SpRuntimeException{
+  public void onNotificationEvent(Event event) throws SpRuntimeException{
     String jsondata =
         "{\"app_id\": \"" + appId + "\",\"contents\": {\"en\": \"" + content + "\"}, \"included_segments\":[\"All\"]}";
 

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
@@ -21,7 +21,6 @@ package org.apache.streampipes.sinks.notifications.jvm.onesignal;
 import org.apache.streampipes.commons.exceptions.SpRuntimeException;
 import org.apache.streampipes.extensions.api.pe.context.EventSinkRuntimeContext;
 import org.apache.streampipes.model.DataSinkType;
-import org.apache.streampipes.model.graph.DataSinkDescription;
 import org.apache.streampipes.model.runtime.Event;
 import org.apache.streampipes.sdk.builder.DataSinkBuilder;
 import org.apache.streampipes.sdk.builder.StreamRequirementsBuilder;
@@ -30,7 +29,7 @@ import org.apache.streampipes.sdk.helpers.Labels;
 import org.apache.streampipes.sdk.helpers.Locales;
 import org.apache.streampipes.sdk.utils.Assets;
 import org.apache.streampipes.wrapper.params.compat.SinkParams;
-import org.apache.streampipes.wrapper.standalone.StreamPipesDataSink;
+import org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -39,10 +38,11 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClients;
 
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-public class OneSignalSink extends StreamPipesDataSink {
+public class OneSignalSink extends StreamPipesNotificationSink {
 
   private static final String CONTENT_KEY = "content";
   private static final String APP_ID = "app_id";
@@ -53,9 +53,9 @@ public class OneSignalSink extends StreamPipesDataSink {
   private String apiKey;
 
   @Override
-  public DataSinkDescription declareModel() {
+  public DataSinkBuilder declareModelWithoutSilentPeriod() {
     return DataSinkBuilder
-        .create("org.apache.streampipes.sinks.notifications.jvm.onesignal", 0)
+        .create("org.apache.streampipes.sinks.notifications.jvm.onesignal", 1)
         .withLocales(Locales.EN)
         .withAssets(Assets.DOCUMENTATION, Assets.ICON)
         .category(DataSinkType.NOTIFICATION)
@@ -65,13 +65,13 @@ public class OneSignalSink extends StreamPipesDataSink {
                             .build())
         .requiredHtmlInputParameter(Labels.withId(CONTENT_KEY))
         .requiredTextParameter(Labels.withId(APP_ID))
-        .requiredTextParameter(Labels.withId(REST_API_KEY))
-        .build();
+        .requiredTextParameter(Labels.withId(REST_API_KEY));
   }
 
   @Override
   public void onInvocation(SinkParams parameters,
                            EventSinkRuntimeContext runtimeContext) throws SpRuntimeException {
+    super.onInvocation(parameters, runtimeContext);
     var extractor = parameters.extractor();
     content = extractor.singleValueParameter(CONTENT_KEY, String.class);
     appId = extractor.singleValueParameter(APP_ID, String.class);
@@ -79,7 +79,7 @@ public class OneSignalSink extends StreamPipesDataSink {
   }
 
   @Override
-  public void onEvent(Event event) throws SpRuntimeException {
+  public void onNotificationEvent(Event inputEvent) throws SpRuntimeException{
     String jsondata =
         "{\"app_id\": \"" + appId + "\",\"contents\": {\"en\": \"" + content + "\"}, \"included_segments\":[\"All\"]}";
 

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/onesignal/OneSignalSink.java
@@ -43,6 +43,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class OneSignalSink extends StreamPipesNotificationSink {
+  public static final String ONE_SIGNAL_NOTIFICATION_SINK_ID =
+      "org.apache.streampipes.sinks.notifications.jvm.onesignal";
 
   private static final String CONTENT_KEY = "content";
   private static final String APP_ID = "app_id";
@@ -55,7 +57,7 @@ public class OneSignalSink extends StreamPipesNotificationSink {
   @Override
   public DataSinkBuilder declareModelWithoutSilentPeriod() {
     return DataSinkBuilder
-        .create("org.apache.streampipes.sinks.notifications.jvm.onesignal", 1)
+        .create(ONE_SIGNAL_NOTIFICATION_SINK_ID, 1)
         .withLocales(Locales.EN)
         .withAssets(Assets.DOCUMENTATION, Assets.ICON)
         .category(DataSinkType.NOTIFICATION)

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/slack/SlackNotificationSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/slack/SlackNotificationSink.java
@@ -111,8 +111,8 @@ public class SlackNotificationSink extends StreamPipesNotificationSink {
   }
 
   @Override
-  public void onNotificationEvent(Event inputEvent) {
-    String message = replacePlaceholders(inputEvent, originalMessage);
+  public void onNotificationEvent(Event event) {
+    String message = replacePlaceholders(event, originalMessage);
     if (this.sendToUser) {
       this.session.sendMessageToUser(userChannel,
                                      message, null);

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/slack/SlackNotificationSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/slack/SlackNotificationSink.java
@@ -40,6 +40,7 @@ import com.ullink.slack.simpleslackapi.impl.SlackSessionFactory;
 import java.io.IOException;
 
 public class SlackNotificationSink extends StreamPipesNotificationSink {
+  public static final String SLACK_NOTIFICATION_SINK_ID = "org.apache.streampipes.sinks.notifications.jvm.slack";
 
   private static final String CHANNEL_TYPE = "channel-type";
   private static final String RECEIVER = "receiver";
@@ -57,7 +58,7 @@ public class SlackNotificationSink extends StreamPipesNotificationSink {
   @Override
   public DataSinkBuilder declareModelWithoutSilentPeriod() {
     return DataSinkBuilder
-        .create("org.apache.streampipes.sinks.notifications.jvm.slack", 1)
+        .create(SLACK_NOTIFICATION_SINK_ID, 1)
         .withLocales(Locales.EN)
         .withAssets(Assets.DOCUMENTATION, Assets.ICON)
         .category(DataSinkType.NOTIFICATION)

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/telegram/TelegramSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/telegram/TelegramSink.java
@@ -82,9 +82,9 @@ public class TelegramSink extends StreamPipesNotificationSink {
   }
 
   @Override
-  public void onNotificationEvent(Event inputEvent) {
+  public void onNotificationEvent(Event event) {
     try {
-      String content = replacePlaceholders(inputEvent, this.message);
+      String content = replacePlaceholders(event, this.message);
       content = trimHTML(content);
       content = URLEncoder.encode(content, StandardCharsets.UTF_8);
       String url = String.format(ENDPOINT, this.apiKey, this.channelOrChatId, content, HTML);

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/telegram/TelegramSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/telegram/TelegramSink.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class TelegramSink extends StreamPipesNotificationSink {
+  public static final String TELEGRAM_NOTIFICATION_SINK_ID = "org.apache.streampipes.sinks.notifications.jvm.telegram";
   private static final String CHANNEL_NAME_OR_CHAT_ID = "channel-chat-name";
   private static final String MESSAGE_TEXT = "message-text";
   private static final String BOT_API_KEY = "api-key";
@@ -58,7 +59,7 @@ public class TelegramSink extends StreamPipesNotificationSink {
   @Override
   public DataSinkBuilder declareModelWithoutSilentPeriod() {
     return DataSinkBuilder
-        .create("org.apache.streampipes.sinks.notifications.jvm.telegram", 1)
+        .create(TELEGRAM_NOTIFICATION_SINK_ID, 1)
         .withLocales(Locales.EN)
         .withAssets(Assets.DOCUMENTATION, Assets.ICON)
         .category(DataSinkType.NOTIFICATION)

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.apache.streampipes.sinks.notifications.jvm.migrations;
 
 import org.apache.streampipes.extensions.api.extractor.IDataSinkParameterExtractor;
@@ -11,7 +29,7 @@ import java.util.ArrayList;
 
 import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.DEFAULT_WAITING_TIME_MINUTES;
 import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.KEY_SILENT_PERIOD;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
@@ -1,0 +1,32 @@
+package org.apache.streampipes.sinks.notifications.jvm.migrations;
+
+import org.apache.streampipes.extensions.api.extractor.IDataSinkParameterExtractor;
+import org.apache.streampipes.model.graph.DataSinkInvocation;
+import org.apache.streampipes.model.migration.MigrationResult;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.KEY_SILENT_PERIOD;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class INotificationDataSinkMigratorTest {
+
+  @Test
+  public void migrate() {
+
+    INotificationDataSinkMigrator migrator = spy(INotificationDataSinkMigrator.class);
+    IDataSinkParameterExtractor extractor = mock(IDataSinkParameterExtractor.class);
+
+    DataSinkInvocation dataSinkInvocation = new DataSinkInvocation();
+    dataSinkInvocation.setStaticProperties(new ArrayList<>());
+
+    MigrationResult<DataSinkInvocation> result = migrator.migrate(dataSinkInvocation, extractor);
+
+    assertEquals(result.element().getStaticProperties().size(), 1);
+    assertEquals(result.element().getStaticProperties().get(0).getInternalName(), KEY_SILENT_PERIOD);
+  }
+}

--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/test/java/org/apache/streampipes/sinks/notifications/jvm/migrations/INotificationDataSinkMigratorTest.java
@@ -3,11 +3,13 @@ package org.apache.streampipes.sinks.notifications.jvm.migrations;
 import org.apache.streampipes.extensions.api.extractor.IDataSinkParameterExtractor;
 import org.apache.streampipes.model.graph.DataSinkInvocation;
 import org.apache.streampipes.model.migration.MigrationResult;
+import org.apache.streampipes.model.staticproperty.FreeTextStaticProperty;
 
 import org.junit.Test;
 
 import java.util.ArrayList;
 
+import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.DEFAULT_WAITING_TIME_MINUTES;
 import static org.apache.streampipes.wrapper.standalone.StreamPipesNotificationSink.KEY_SILENT_PERIOD;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -16,7 +18,7 @@ import static org.mockito.Mockito.spy;
 public class INotificationDataSinkMigratorTest {
 
   @Test
-  public void migrate() {
+  public void testNotificationDataSinkMigration() {
 
     INotificationDataSinkMigrator migrator = spy(INotificationDataSinkMigrator.class);
     IDataSinkParameterExtractor extractor = mock(IDataSinkParameterExtractor.class);
@@ -26,7 +28,10 @@ public class INotificationDataSinkMigratorTest {
 
     MigrationResult<DataSinkInvocation> result = migrator.migrate(dataSinkInvocation, extractor);
 
-    assertEquals(result.element().getStaticProperties().size(), 1);
-    assertEquals(result.element().getStaticProperties().get(0).getInternalName(), KEY_SILENT_PERIOD);
+    assertEquals(1, result.element().getStaticProperties().size());
+
+    var property = (FreeTextStaticProperty) result.element().getStaticProperties().get(0);
+    assertEquals(KEY_SILENT_PERIOD, property.getInternalName());
+    assertEquals(DEFAULT_WAITING_TIME_MINUTES, Integer.valueOf(property.getValue()).intValue());
   }
 }

--- a/streampipes-wrapper-standalone/src/main/java/org/apache/streampipes/wrapper/standalone/StreamPipesNotificationSink.java
+++ b/streampipes-wrapper-standalone/src/main/java/org/apache/streampipes/wrapper/standalone/StreamPipesNotificationSink.java
@@ -41,12 +41,12 @@ public abstract class StreamPipesNotificationSink extends StreamPipesDataSink {
   /**
    * Default waiting time in minutes between two consecutive notifications.
    */
-  private static final int DEFAULT_WAITING_TIME_MINUTES = 10;
+  public static final int DEFAULT_WAITING_TIME_MINUTES = 10;
 
   /**
    * Key for the silent period parameter.
    */
-  private static final String KEY_SILENT_PERIOD = "silentPeriod";
+  public static final String KEY_SILENT_PERIOD = "silentPeriod";
 
   /**
    * The epoch second of the last message sent.


### PR DESCRIPTION
Purpose

For the following sinks: OneSignalSink, SlackSink, TelegramSink

Refactored to extend StreamPipesNotificationSink interface
Implemented migrations with the use of a common interface INotificationDataSinkMigrator

Added a unit test for INotificationDataSinkMigrator

Remarks
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no