### PR TITLE
fix(#2551): prevent Python functions from creating multiple output streams 

### DIFF
--- a/streampipes-client-python/streampipes/endpoint/endpoint.py
+++ b/streampipes-client-python/streampipes/endpoint/endpoint.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 
 # define custom logging messages for some specific HTTP status
 _error_code_to_message = {
+    400: "\nThe StreamPipes Backend did not accept the request. Please check the logs for details",
     401: "\nThe StreamPipes Backend returned an unauthorized error.\n"
     "Please check your user name and/or password to be correct.",
     403: "\nThere seems to be an issue with the access rights of the given user and the resource you queried.\n"

--- a/streampipes-client-python/streampipes/endpoint/endpoint.py
+++ b/streampipes-client-python/streampipes/endpoint/endpoint.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 # define custom logging messages for some specific HTTP status
 _error_code_to_message = {
-    400: "\nThe StreamPipes Backend did not accept the request. Please check the logs for details",
+    400: "\nThe StreamPipes Backend did not accept the request. Please check the logs for details.\n",
     401: "\nThe StreamPipes Backend returned an unauthorized error.\n"
     "Please check your user name and/or password to be correct.",
     403: "\nThere seems to be an issue with the access rights of the given user and the resource you queried.\n"
@@ -150,13 +150,14 @@ class APIEndpoint(Endpoint):
             error_message = _error_code_to_message[status_code]
 
             if status_code in [
+                HTTPStatus.BAD_REQUEST.numerator,
                 HTTPStatus.METHOD_NOT_ALLOWED.numerator,
                 HTTPStatus.NOT_FOUND.numerator,
             ]:
                 error_message += f"url: {err.response.url}\nstatus code: {status_code}"
 
             logger.debug(f"HTTP error response: {err.response.text}")
-            raise HTTPError(error_message) from err
+            raise HTTPError(error_message, response=response) from err
 
         else:
             logger.debug("Successfully retrieved resources from %s.", url)

--- a/streampipes-client-python/streampipes/functions/function_handler.py
+++ b/streampipes-client-python/streampipes/functions/function_handler.py
@@ -73,9 +73,9 @@ class FunctionHandler:
                 try:
                     self.client.dataStreamApi.post(output_stream)
                 except HTTPError as e:
-                    logger.warning("The data stream could not be created.")
+                    logger.info("The data stream could not be created.")
                     if e.response.status_code == HTTPStatus.BAD_REQUEST:
-                        logger.warning(
+                        logger.info(
                             "This is due to the fact that this data stream already exists. "
                             "Continuing with the existing data stream."
                         )

--- a/streampipes-client-python/streampipes/model/resource/data_stream.py
+++ b/streampipes-client-python/streampipes/model/resource/data_stream.py
@@ -86,7 +86,7 @@ class DataStream(Resource):
             self.uri = self.element_id
 
     class_name: StrictStr = Field(alias="@class", default_factory=lambda: "org.apache.streampipes.model.SpDataStream")
-    element_id: Optional[StrictStr] = None
+    element_id: StrictStr = Field(default="")
     name: StrictStr = Field(default="Unnamed")
     description: Optional[StrictStr]
     icon_url: Optional[StrictStr]

--- a/streampipes-client-python/streampipes/model/resource/data_stream.py
+++ b/streampipes-client-python/streampipes/model/resource/data_stream.py
@@ -24,7 +24,6 @@ from streampipes.model.common import (
     EventSchema,
     MeasurementCapability,
     MeasurementObject,
-    random_letters,
 )
 from streampipes.model.resource.resource import Resource
 
@@ -81,11 +80,13 @@ class DataStream(Resource):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        if not self.element_id:
+            self.element_id = f"sp:spdatastream:{self.name.replace(':', '')}"
         if not self.uri:
             self.uri = self.element_id
 
     class_name: StrictStr = Field(alias="@class", default_factory=lambda: "org.apache.streampipes.model.SpDataStream")
-    element_id: StrictStr = Field(default_factory=lambda: f"sp:spdatastream:{random_letters(6)}")
+    element_id: Optional[StrictStr] = None
     name: StrictStr = Field(default="Unnamed")
     description: Optional[StrictStr]
     icon_url: Optional[StrictStr]


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
As for now, a function always creates a new data stream entity at the backend when starting a Python function with an output stream. This is not how it should behave because this prevents one from restarting a Python-based function.
With this PR, the identifier of the function is deterministically created and therefore reusable. If the data stream already exists, an info statement is logged and the function uses the existing stream.
The identification of a stream is based on its name. As long as one provides a consistent name for a data stream, the same stream will be used.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no
PR introduces (a) deprecation(s): no
