### PR TITLE
test(#2374): provide a framework to easily unit test processing elements

### DIFF
--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
@@ -18,106 +18,76 @@
 
 package org.apache.streampipes.processors.filters.jvm.processor.booleanfilter;
 
-import org.apache.streampipes.extensions.api.pe.context.EventProcessorRuntimeContext;
-import org.apache.streampipes.model.runtime.Event;
-import org.apache.streampipes.model.runtime.EventFactory;
-import org.apache.streampipes.model.runtime.SchemaInfo;
-import org.apache.streampipes.model.runtime.SourceInfo;
-import org.apache.streampipes.sdk.extractor.ProcessingElementParameterExtractor;
-import org.apache.streampipes.test.extensions.api.StoreEventCollector;
-import org.apache.streampipes.wrapper.params.compat.ProcessorParams;
+
+import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
+
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class TestBooleanFilterProcessor {
-  private static final String STREAM_PREFIX = "s0::";
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestBooleanFilterProcessor.class);
+  private static final String FIELD_NAME = "Test";
+  private static final String FIELD_NAME_WITH_PREFIX = "s0::" + FIELD_NAME;
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(
+      String boolToKeep,
+      List<Boolean> eventBooleans,
+      List<Boolean> outputEventBooleans
+  ) {
+
+    var processor = new BooleanFilterProcessor();
+
+    Map<String, Object> userConfiguration =
+        Map.of(
+            BooleanFilterProcessor.BOOLEAN_MAPPING, FIELD_NAME_WITH_PREFIX,
+            BooleanFilterProcessor.VALUE, boolToKeep
+        );
+
+    List<Map<String, Object>> events = new ArrayList<>();
+    eventBooleans.forEach(bool->events.add(Map.of(FIELD_NAME_WITH_PREFIX, bool)));
+
+    List<Map<String, Object>> outputEvents = new ArrayList<>();
+    outputEventBooleans.forEach(bool->outputEvents.add(Map.of(FIELD_NAME, bool)));
+
+    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, null);
+  }
 
   static Stream<Arguments> data() {
     return Stream.of(
-        Arguments.of("True", Arrays.asList(true, true, false, true, false, true, false, true), 5),
-        Arguments.of("True", Arrays.asList(true, true, true), 3),
-        Arguments.of("True", Arrays.asList(false, false, false), 0),
-        Arguments.of("True", Collections.emptyList(), 0),
-        Arguments.of("False", Arrays.asList(true, false, true, false, true, false, true, false, true), 4),
-        Arguments.of("False", Arrays.asList(true, true, true), 0),
-        Arguments.of("False", Arrays.asList(false, false, false), 3),
-        Arguments.of("False", Collections.emptyList(), 0)
-    );
-  }
-
-  @ParameterizedTest
-  @MethodSource("data")
-  public void testBoolenFilter(
-      String boolToKeep,
-      List<Boolean> eventBooleans,
-      int expectedFilteredBooleanCount
-  ) {
-
-    var fieldName = "Test";
-    var processorParams = mock(ProcessorParams.class);
-    var eventProcessorRuntimeContext = mock(EventProcessorRuntimeContext.class);
-
-    var processor = new BooleanFilterProcessor();
-    var extractor = mock(ProcessingElementParameterExtractor.class);
-    when(processorParams.extractor()).thenReturn(extractor);
-    when(extractor.mappingPropertyValue(BooleanFilterProcessor.BOOLEAN_MAPPING)).thenReturn(STREAM_PREFIX + fieldName);
-    when(extractor.selectedSingleValue(BooleanFilterProcessor.VALUE, String.class)).thenReturn(boolToKeep);
-
-    var collector = new StoreEventCollector();
-    processor.onInvocation(processorParams, collector, eventProcessorRuntimeContext);
-
-    sendEvents(processor, collector, eventBooleans, fieldName);
-
-    assertEquals(expectedFilteredBooleanCount, collector.getEvents().size());
-  }
-
-  private void sendEvents(
-      BooleanFilterProcessor processor,
-      StoreEventCollector collector,
-      List<Boolean> eventBooleans,
-      String fieldName) {
-    List<Event> events = makeEvents(eventBooleans, fieldName);
-    for (Event event : events) {
-      LOG.info("Sending event with value "
-                   + event.getFieldBySelector(STREAM_PREFIX + fieldName)
-                          .getAsPrimitive()
-                          .getAsBoolean());
-      processor.onEvent(event, collector);
-
-    }
-  }
-
-  private List<Event> makeEvents(List<Boolean> eventBooleans, String fieldName) {
-    List<Event> events = new ArrayList<>();
-    for (Boolean eventSetting : eventBooleans) {
-      events.add(makeEvent(eventSetting, fieldName));
-    }
-    return events;
-  }
-
-  private Event makeEvent(Boolean value, String fieldName) {
-    Map<String, Object> map = new HashMap<>();
-    map.put(fieldName, value);
-    return EventFactory.fromMap(map, new SourceInfo("test" + "-topic", "s0"),
-                                new SchemaInfo(null, new ArrayList<>())
+        Arguments.of("True",
+            Arrays.asList(true, true, false, true, false, true, false, true),
+            Arrays.asList(true, true, true, true, true)),
+        Arguments.of("True",
+            Arrays.asList(true, true, true),
+            Arrays.asList(true, true, true)),
+        Arguments.of("True",
+            Arrays.asList(false, false, false),
+            Collections.emptyList()),
+        Arguments.of("True",
+            Collections.emptyList(),
+            Collections.emptyList()),
+        Arguments.of("False",
+            Arrays.asList(true, false, true, false, true, false, true, false, true),
+            Arrays.asList(false, false, false, false)),
+        Arguments.of("False",
+            Arrays.asList(true, true, true),
+            Collections.emptyList()),
+        Arguments.of("False",
+            Arrays.asList(false, false, false),
+            Arrays.asList(false, false, false)),
+        Arguments.of("False",
+            Collections.emptyList(),
+            Collections.emptyList())
     );
   }
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
@@ -22,6 +22,7 @@ package org.apache.streampipes.processors.filters.jvm.processor.booleanfilter;
 import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
 
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,8 +36,13 @@ import java.util.stream.Stream;
 
 public class TestBooleanFilterProcessor {
 
+  BooleanFilterProcessor processor;
   private static final String FIELD_NAME = "Test";
   private static final String FIELD_NAME_WITH_PREFIX = "s0::" + FIELD_NAME;
+  @BeforeEach
+  public void setup(){
+    processor = new BooleanFilterProcessor();
+  }
   @ParameterizedTest
   @MethodSource("data")
   public void test(
@@ -44,8 +50,6 @@ public class TestBooleanFilterProcessor {
       List<Boolean> eventBooleans,
       List<Boolean> outputEventBooleans
   ) {
-
-    var processor = new BooleanFilterProcessor();
 
     Map<String, Object> userConfiguration =
         Map.of(

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/booleanfilter/TestBooleanFilterProcessor.java
@@ -63,7 +63,9 @@ public class TestBooleanFilterProcessor {
     List<Map<String, Object>> outputEvents = new ArrayList<>();
     outputEventBooleans.forEach(bool->outputEvents.add(Map.of(FIELD_NAME, bool)));
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, null);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    testExecutor.run(events, outputEvents);
   }
 
   static Stream<Arguments> data() {

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/compose/TestComposeProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/compose/TestComposeProcessor.java
@@ -18,124 +18,85 @@
 
 package org.apache.streampipes.processors.filters.jvm.processor.compose;
 
-//@RunWith(Parameterized.class)
+import org.apache.streampipes.model.graph.DataProcessorInvocation;
+import org.apache.streampipes.model.output.CustomOutputStrategy;
+import org.apache.streampipes.model.output.OutputStrategy;
+import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
 public class TestComposeProcessor {
-//
-//  private static final Logger LOG = LoggerFactory.getLogger(TestComposeProcessor.class);
-//
-//  @org.junit.runners.Parameterized.Parameter
-//  public String testName;
-//
-//  @org.junit.runners.Parameterized.Parameter(1)
-//  public List<Map<String, Object>> eventMaps;
-//
-//  @org.junit.runners.Parameterized.Parameter(2)
-//  public List<String> selectorPrefixes;
-//
-//  @org.junit.runners.Parameterized.Parameter(3)
-//  public int expectedNumOfEvents;
-//
-//  @org.junit.runners.Parameterized.Parameter(4)
-//  public int expectedEventSize;
-//
-//  private static final String outputKeySelector1 = "key-selector1";
-//  private static final String outputKeySelector2 = "key-selector2";
-//
-//  @org.junit.runners.Parameterized.Parameters
-//  public static Iterable<Object[]> data() {
-//    Map<String, Object> mapWithFirstOutputSelector = new HashMap<>();
-//    mapWithFirstOutputSelector.put(outputKeySelector1, new Object());
-//
-//    Map<String, Object> mapWithSecondOutputSelector = new HashMap<>();
-//    mapWithSecondOutputSelector.put(outputKeySelector2, new Object());
-//
-//    Map<String, Object> mapWithInvalidOutputSelector = new HashMap<>();
-//    mapWithInvalidOutputSelector.put("invalid-selector", new Object());
-//
-//    List<Map<String, Object>> singleMap = new ArrayList<>();
-//    singleMap.add(mapWithFirstOutputSelector);
-//
-//    List<Map<String, Object>> twoMapsMatching = new ArrayList<>();
-//    twoMapsMatching.add(mapWithFirstOutputSelector);
-//    twoMapsMatching.add(mapWithSecondOutputSelector);
-//
-//    List<Map<String, Object>> twoMapsOneMatching = new ArrayList<>();
-//    twoMapsOneMatching.add(mapWithFirstOutputSelector);
-//    twoMapsOneMatching.add(mapWithInvalidOutputSelector);
-//
-//    List<Map<String, Object>> twoMapsNoneMatching = new ArrayList<>();
-//    twoMapsNoneMatching.add(mapWithInvalidOutputSelector);
-//    twoMapsNoneMatching.add(new HashMap<>(mapWithInvalidOutputSelector));
-//
-//    return Arrays.asList(new Object[][]{
-//            {"testWithOneEvent", singleMap, List.of("s0"), 0, 0},
-//            {"testWithTwoEventsSamePrefix", twoMapsMatching, List.of("s0", "s0"), 0, 0},
-//            {"testWithTwoEvents", twoMapsMatching, List.of("s0", "s1"), 1, 2},
-//            {"testWithTwoEventsAnd1InvalidSelector", twoMapsOneMatching, List.of("s0", "s1"), 1, 1},
-//            {"testWithTwoEventsWithInvalidSelectors", twoMapsNoneMatching, List.of("s0", "s1"), 1, 0}
-//    });
-//  }
-//
-//
-//
-//  @Test
-//  public void testComposeProcessor() {
-//    LOG.info("Executing test: {}", testName);
-//    var processor = new ComposeProcessor();
-//    var originalGraph = processor.declareModel();
-//    originalGraph.setSupportedGrounding(EventGroundingGenerator.makeDummyGrounding());
-//
-//    var graph = InvocationGraphGenerator.makeEmptyInvocation(originalGraph);
-//    List<OutputStrategy> outputStrategies = new ArrayList<>();
-//    outputStrategies.add(new CustomOutputStrategy(List.of("s0::" + outputKeySelector1, "s1::" + outputKeySelector2)));
-//    graph.setOutputStrategies(outputStrategies);
-//    var params = new ProcessorParams(graph);
-//
-//    var eventCollector = new StoreEventCollector();
-//    processor.onInvocation(params, eventCollector, null);
-//
-//    List<Event> collectedEvents = sendEvents(processor, eventCollector);
-//
-//    LOG.info("Expected collected event count is: {}", expectedNumOfEvents);
-//    LOG.info("Actual collected event count is: {}", collectedEvents.size());
-//    assertEquals(expectedNumOfEvents, collectedEvents.size());
-//
-//    if (!collectedEvents.isEmpty()){
-//      int eventSize = collectedEvents.get(0).getFields().size();
-//
-//      LOG.info("Expected event size is: {}", expectedEventSize);
-//      LOG.info("Actual event size is: {}", eventSize);
-//      assertEquals(expectedEventSize, eventSize);
-//    }
-//  }
-//
-//  private List<Event> sendEvents(ComposeProcessor processor, StoreEventCollector collector) {
-//    List<Event> events = makeEvents();
-//    for (Event event : events) {
-//      LOG.info("Sending event with map: " + event.getFields()
-//              + ", and prefix selector: " + event.getSourceInfo().getSelectorPrefix());
-//      processor.onEvent(event, collector);
-//      try {
-//        Thread.sleep(100);
-//      } catch (InterruptedException e) {
-//        e.printStackTrace();
-//      }
-//    }
-//    return collector.getEvents();
-//  }
-//  private List<Event> makeEvents() {
-//    List<Event> events = new ArrayList<>();
-//    for (int i = 0; i < eventMaps.size(); i++) {
-//      events.add(makeEvent(eventMaps.get(i), selectorPrefixes.get(i)));
-//    }
-//    return events;
-//  }
-//
-//  private Event makeEvent(Map<String, Object> eventMap, String selectorPrefix) {
-//    return EventFactory.fromMap(eventMap, new SourceInfo("test" + "-topic", selectorPrefix),
-//            new SchemaInfo(null, new ArrayList<>()));
-//  }
+
+  ComposeProcessor processor;
+  private static final String SELECTOR_1 = "key-selector1";
+  private static final String SELECTOR_2 = "key-selector2";
+  private static final String INVALID_SELECTOR = "invalid-selector";
+  private static final String S0_PREFIX = "s0::";
+  private static final String S1_PREFIX = "s1::";
+
+  @BeforeEach
+  public void setup(){
+    processor = new ComposeProcessor();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(List<Map<String, Object>> events,
+                   List<Map<String, Object>> outputEvents) {
+
+    Consumer<DataProcessorInvocation> invocationConfig = (invocation->{
+      List<OutputStrategy> outputStrategies = new ArrayList<>();
+      outputStrategies.add(new CustomOutputStrategy(List.of(S0_PREFIX + SELECTOR_1, S1_PREFIX + SELECTOR_2)));
+      invocation.setOutputStrategies(outputStrategies);
+    });
+
+    ProcessingElementTestExecutor.run(processor, Map.of(), events, outputEvents, invocationConfig);
+  }
+  static Stream<Arguments> data() {
+
+    var object1 = new Object();
+    var object2 = new Object();
+
+    return Stream.of(
+        Arguments.of(
+            List.of(
+              Map.of(S0_PREFIX + SELECTOR_1, object1)),
+            List.of()),
+        Arguments.of(
+            List.of(
+              Map.of(S0_PREFIX + SELECTOR_1, object1),
+              Map.of(S0_PREFIX + SELECTOR_2, object2)),
+            List.of()),
+        Arguments.of(
+            List.of(
+                Map.of(S0_PREFIX + SELECTOR_1, object1),
+                Map.of(S1_PREFIX + SELECTOR_2, object2)),
+            List.of(
+                Map.of(SELECTOR_1, object1, SELECTOR_2, object2)
+            )),
+        Arguments.of(
+            List.of(
+                Map.of(S0_PREFIX + SELECTOR_1, object1),
+                Map.of(S1_PREFIX + INVALID_SELECTOR, object2)),
+            List.of(
+                Map.of(SELECTOR_1, object1)
+            )),
+        Arguments.of(
+            List.of(
+                Map.of(S0_PREFIX + INVALID_SELECTOR, object1),
+                Map.of(S1_PREFIX + INVALID_SELECTOR, object2)),
+            List.of(
+                Map.of()
+            ))
+    );
+  }
 }
-
-
-

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/compose/TestComposeProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/compose/TestComposeProcessor.java
@@ -59,7 +59,9 @@ public class TestComposeProcessor {
       invocation.setOutputStrategies(outputStrategies);
     });
 
-    ProcessingElementTestExecutor.run(processor, Map.of(), events, outputEvents, invocationConfig);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, invocationConfig);
+
+    testExecutor.run(events, outputEvents);
   }
   static Stream<Arguments> data() {
 

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/merge/TestMergeByTimeProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/merge/TestMergeByTimeProcessor.java
@@ -17,145 +17,118 @@
  */
 package org.apache.streampipes.processors.filters.jvm.processor.merge;
 
-//@RunWith(Parameterized.class)
+import org.apache.streampipes.model.graph.DataProcessorInvocation;
+import org.apache.streampipes.model.output.CustomOutputStrategy;
+import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+
+
 public class TestMergeByTimeProcessor {
-//
-//  private static final Logger LOG = LoggerFactory.getLogger(TestMergeByTimeProcessor.class);
-//
-//  private static final Integer timeInterval = 100;
-//  @org.junit.runners.Parameterized.Parameter
-//  public String testName;
-//  @org.junit.runners.Parameterized.Parameter(1)
-//  public List<String> eventStrings;
-//  @org.junit.runners.Parameterized.Parameter(2)
-//  public List<String> expectedValue;
-//
-//  @org.junit.runners.Parameterized.Parameters
-//  public static Iterable<Object[]> data() {
-//    return Arrays.asList(new Object[][]{
-//        {"testWithInInterval", Arrays.asList("s0:0", "s1:90"), List.of("(90,0)")},
-//        {"testNotWithInInterval", Arrays.asList("s0:0", "s1:110"), List.of()},
-//        {"testWithInAndNotWithInInterval", Arrays.asList("s0:0", "s1:80", "s0:110", "s1:500"),
-//            List.of("(80,0)")},
-//        {"testFigGvnInDocs",
-//            Arrays.asList("s1:0", "s0:10", "s0:110", "s1:115", "s0:120", "s1:230", "s0:340", "s0:500",
-//                "s1:510"),
-//            Arrays.asList("(0,10)", "(115,110)", "(510,500)")}
-//    });
-//  }
-//
-//  @Test
-//  public void testMergeByTimeProcessor() {
-//    MergeByTimeProcessor mergeByTimeProcessor = new MergeByTimeProcessor();
-//    DataProcessorDescription originalGraph = mergeByTimeProcessor.declareModel();
-//    originalGraph.setSupportedGrounding(EventGroundingGenerator.makeDummyGrounding());
-//
-//    DataProcessorInvocation graph = InvocationGraphGenerator.makeEmptyInvocation(originalGraph);
-//    graph.setInputStreams(Arrays.asList(
-//        EventStreamGenerator.makeStreamWithProperties(Collections.singletonList("in-stram0")),
-//        EventStreamGenerator.makeStreamWithProperties(Collections.singletonList("in-stream1"))
-//    ));
-//
-//    graph.setOutputStream(
-//        EventStreamGenerator.makeStreamWithProperties(Collections.singletonList("out-stream"))
-//    );
-//    graph.getOutputStream().getEventGrounding().getTransportProtocol().getTopicDefinition()
-//        .setActualTopicName("output-topic");
-//
-//    List<String> outputKeySelectors = graph.getOutputStrategies()
-//        .stream()
-//        .filter(CustomOutputStrategy.class::isInstance)
-//        .map(o -> (CustomOutputStrategy) o)
-//        .findFirst()
-//        .map(CustomOutputStrategy::getSelectedPropertyKeys)
-//        .orElse(new ArrayList<>());
-//    outputKeySelectors.add("s0::timestamp_mapping_stream_1");
-//    outputKeySelectors.add("s1::timestamp_mapping_stream_2");
-//
-//    List<MappingPropertyUnary> mappingPropertyUnaries = graph.getStaticProperties()
-//        .stream()
-//        .filter(p -> p instanceof MappingPropertyUnary)
-//        .map((p -> (MappingPropertyUnary) p))
-//        .filter(p -> Arrays.asList(
-//                MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY,
-//                MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY)
-//            .contains(p.getInternalName()))
-//        .collect(Collectors.toList());
-//
-//    assert mappingPropertyUnaries.size() == 2;
-//    mappingPropertyUnaries.get(0)
-//        .setSelectedProperty("s0::" + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY);
-//    mappingPropertyUnaries.get(1)
-//        .setSelectedProperty("s1::" + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY);
-//
-//    FreeTextStaticProperty fsp = graph.getStaticProperties().stream()
-//        .filter(p -> p instanceof FreeTextStaticProperty)
-//        .map((p -> (FreeTextStaticProperty) p))
-//        .filter(p -> p.getInternalName().equals(MergeByTimeProcessor.TIME_INTERVAL))
-//        .findFirst().orElse(null);
-//    assert fsp != null;
-//    fsp.setValue(String.valueOf(timeInterval));
-//
-//    ProcessorParams params = new ProcessorParams(graph);
-//
-//    StoreEventCollector collector = new StoreEventCollector();
-//
-//    mergeByTimeProcessor.onInvocation(params, collector, null);
-//    sendEvents(mergeByTimeProcessor, collector);
-//
-//    List<String> actualCollectedEvents = collector.getEvents().stream()
-//        .map(e -> formatMergedEvent(e))
-//        .collect(Collectors.toList());
-//
-//    LOG.info("Expected merged event is {}", expectedValue);
-//    LOG.info("Actual merged event is {}", actualCollectedEvents);
-//    assertTrue(eventsEquals(expectedValue, actualCollectedEvents));
-//  }
-//
-//  private boolean eventsEquals(List<String> expectedValue, List<String> actualCollectedEvents) {
-//    if (expectedValue.size() != actualCollectedEvents.size()) {
-//      return false;
-//    }
-//    for (int i = 0; i < expectedValue.size(); i++) {
-//      if (!expectedValue.get(i).equalsIgnoreCase(actualCollectedEvents.get(i))) {
-//        return false;
-//      }
-//    }
-//    return true;
-//  }
-//
-//  private String formatMergedEvent(Event mergedEvent) {
-//    return String.format("(%s)", mergedEvent.getFields().values().stream()
-//        .map(m -> m.getAsPrimitive().getAsString()).collect(Collectors.joining(",")));
-//  }
-//
-//  private void sendEvents(MergeByTimeProcessor mergeByTimeProcessor, StoreEventCollector spOut) {
-//    List<Event> events = makeEvents();
-//    for (Event event : events) {
-//      mergeByTimeProcessor.onEvent(event, spOut);
-//    }
-//
-//  }
-//
-//  private List<Event> makeEvents() {
-//    List<Event> events = Lists.newArrayList();
-//    for (String eventString : eventStrings) {
-//      events.add(makeEvent(eventString));
-//    }
-//    return events;
-//  }
-//
-//  private Event makeEvent(String eventString) {
-//    Map<String, Object> map = Maps.newHashMap();
-//    String streamId = eventString.split(":")[0];
-//    String timestamp = eventString.split(":")[1];
-//    if (streamId.equals("s0")) {
-//      map.put(MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, timestamp);
-//    } else {
-//      map.put(MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, timestamp);
-//    }
-//    return EventFactory.fromMap(map,
-//        new SourceInfo("test", streamId),
-//        new SchemaInfo(null, Lists.newArrayList()));
-//  }
+
+  private static final String S0_PREFIX = "s0::";
+  private static final String S1_PREFIX = "s1::";
+  private static final Integer timeInterval = 100;
+
+  MergeByTimeProcessor processor;
+
+  @BeforeEach
+  public void setup(){
+    processor = new MergeByTimeProcessor();
+  }
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(List<Map<String, Object>> events,
+                   List<Map<String, Object>> outputEvents){
+
+
+    Map<String, Object> userConfiguration =
+        Map.of(
+            MergeByTimeProcessor.TIME_INTERVAL, timeInterval,
+            MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY,
+            S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY,
+            MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY,
+            S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY
+    );
+
+    Consumer<DataProcessorInvocation> invocationConfig = (invocation->{
+      List<String> outputKeySelectors = invocation.getOutputStrategies()
+          .stream()
+          .filter(CustomOutputStrategy.class::isInstance)
+          .map(o -> (CustomOutputStrategy) o)
+          .findFirst()
+          .map(CustomOutputStrategy::getSelectedPropertyKeys)
+          .orElse(new ArrayList<>());
+      outputKeySelectors.add(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY);
+      outputKeySelectors.add(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY);
+    });
+
+    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, invocationConfig);
+  }
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(List.of(
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "0"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "90")
+            ),
+            List.of(
+                Map.of(
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "90",
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "0"
+                )
+            )),
+        Arguments.of(List.of(
+            Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "0"),
+            Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "110")
+        ), List.of()),
+        Arguments.of(List.of(
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "0"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "80"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "110"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "500")
+            ),
+            List.of(
+                Map.of(
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "80",
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "0"
+                )
+            )),
+        Arguments.of(List.of(
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "0"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "10"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "110"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "115"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "120"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "230"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "340"),
+                Map.of(S0_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "500"),
+                Map.of(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "510")
+            ),
+            List.of(
+                Map.of(
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "0",
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "10"
+                ),
+                Map.of(
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "115",
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "110"
+                ),
+                Map.of(
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY, "510",
+                    MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_1_KEY, "500"
+                )
+            ))
+    );
+  }
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/merge/TestMergeByTimeProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/merge/TestMergeByTimeProcessor.java
@@ -73,7 +73,10 @@ public class TestMergeByTimeProcessor {
       outputKeySelectors.add(S1_PREFIX + MergeByTimeProcessor.TIMESTAMP_MAPPING_STREAM_2_KEY);
     });
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, invocationConfig);
+    ProcessingElementTestExecutor testExecutor =
+        new ProcessingElementTestExecutor(processor, userConfiguration, invocationConfig);
+
+    testExecutor.run(events, outputEvents);
   }
 
   static Stream<Arguments> data() {

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/NumericalFilterProcessorTest.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/NumericalFilterProcessorTest.java
@@ -18,19 +18,19 @@
 
 package org.apache.streampipes.processors.filters.jvm.processor.numericalfilter;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 public class NumericalFilterProcessorTest {
 
-  private static final String PROPERTY_NAME = "proptertyName";
+  private static final String PROPERTY_NAME = "propertyName";
   private NumericalFilterProcessor processor;
 
 
-  @Before
+  @BeforeEach
   public void setup() {
     processor = new NumericalFilterProcessor();
   }
@@ -54,7 +54,7 @@ public class NumericalFilterProcessorTest {
     );
 
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents);
+    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
   }
 
   @Test
@@ -74,7 +74,7 @@ public class NumericalFilterProcessorTest {
     List<Map<String, Object>> outputEvents = List.of();
 
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents);
+    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
   }
 
 

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/NumericalFilterProcessorTest.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/NumericalFilterProcessorTest.java
@@ -53,8 +53,9 @@ public class NumericalFilterProcessorTest {
         Map.of(PROPERTY_NAME, 1.0f)
     );
 
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
+    testExecutor.run(inputEvents, outputEvents);
   }
 
   @Test
@@ -73,9 +74,9 @@ public class NumericalFilterProcessorTest {
 
     List<Map<String, Object>> outputEvents = List.of();
 
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
+    testExecutor.run(inputEvents, outputEvents);
   }
-
 
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
@@ -42,8 +42,6 @@ import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,50 +49,39 @@ import static org.mockito.Mockito.when;
 
 public class ProcessingElementTestExecutor {
 
-  /**
-   * This method is used to run a data processor with a given configuration and a list of input events.
-   * It then verifies the output events against the expected output events.
-   *
-   * @param processor            The data processor under test.
-   * @param userConfiguration    The user input configuration for the processor.
-   * @param inputEvents          The list of input events to be processed.
-   * @param expectedOutputEvents The list of expected output events.
-   * @param expectedException    Exception expected to occur.
-   */
-  public static void runWithException(
-      IStreamPipesDataProcessor processor,
-      Map<String, Object> userConfiguration,
-      List<Map<String, Object>> inputEvents,
-      List<Map<String, Object>> expectedOutputEvents,
-      Consumer<DataProcessorInvocation> invocationConfig,
-      Exception expectedException
-  ) {
-    Exception exception = assertThrows(expectedException.getClass(), () -> {
-      run(processor, userConfiguration, inputEvents, expectedOutputEvents, invocationConfig);
-    });
+  private final IStreamPipesDataProcessor processor;
+  private final Map<String, Object> userConfiguration;
+  private Consumer<DataProcessorInvocation> invocationConfig;
 
-    String expectedMessage = expectedException.getMessage();
-    String actualMessage = exception.getMessage();
+  public ProcessingElementTestExecutor(IStreamPipesDataProcessor processor, Map<String, Object> userConfiguration,
+                                       Consumer<DataProcessorInvocation> invocationConfig) {
+    this.processor = processor;
+    this.userConfiguration = userConfiguration;
+    this.invocationConfig = invocationConfig;
+  }
 
-    assertTrue(actualMessage.contains(expectedMessage));
+  public ProcessingElementTestExecutor(IStreamPipesDataProcessor processor, Map<String, Object> userConfiguration) {
+    this.processor = processor;
+    this.userConfiguration = userConfiguration;
+  }
 
+  public ProcessingElementTestExecutor(IStreamPipesDataProcessor processor,
+                                       Consumer<DataProcessorInvocation> invocationConfig) {
+    this.processor = processor;
+    this.userConfiguration = new HashMap<>();
+    this.invocationConfig = invocationConfig;
   }
 
   /**
    * This method is used to run a data processor with a given configuration and a list of input events.
    * It then verifies the output events against the expected output events.
    *
-   * @param processor            The data processor under test.
-   * @param userConfiguration    The user input configuration for the processor.
    * @param inputEvents          The list of input events to be processed.
    * @param expectedOutputEvents The list of expected output events.
    */
-  public static void run(
-      IStreamPipesDataProcessor processor,
-      Map<String, Object> userConfiguration,
+  public void run(
       List<Map<String, Object>> inputEvents,
-      List<Map<String, Object>> expectedOutputEvents,
-      Consumer<DataProcessorInvocation> invocationConfig
+      List<Map<String, Object>> expectedOutputEvents
   ) {
 
 

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
@@ -100,7 +100,7 @@ public class ProcessingElementTestExecutor {
 
     // initialize the extractor with the provided configuration of the user input
     var dataProcessorInvocation = getProcessorInvocation(processor, userConfiguration);
-    if (!(invocationConfig == null)){
+    if (invocationConfig != null){
       invocationConfig.accept(dataProcessorInvocation);
     }
 

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/numericalfilter/ProcessingElementTestExecutor.java
@@ -86,7 +86,7 @@ public class ProcessingElementTestExecutor {
 
 
     // initialize the extractor with the provided configuration of the user input
-    var dataProcessorInvocation = getProcessorInvocation(processor, userConfiguration);
+    var dataProcessorInvocation = getProcessorInvocation();
     if (invocationConfig != null){
       invocationConfig.accept(dataProcessorInvocation);
     }
@@ -130,11 +130,8 @@ public class ProcessingElementTestExecutor {
     return ProcessingElementParameterExtractor.from(dataProcessorInvocation);
   }
 
-  private static DataProcessorInvocation getProcessorInvocation(
-      IStreamPipesDataProcessor processor,
-      Map<String, Object> userConfiguration
-  ) {
-    var pipelineElementTemplate = getPipelineElementTemplate(processor, userConfiguration);
+  private DataProcessorInvocation getProcessorInvocation() {
+    var pipelineElementTemplate = getPipelineElementTemplate();
 
     var invocation = new DataProcessorInvocation(
         processor
@@ -153,10 +150,7 @@ public class ProcessingElementTestExecutor {
         .applyTemplateOnPipelineElement();
   }
 
-  private static PipelineElementTemplate getPipelineElementTemplate(
-      IStreamPipesDataProcessor processor,
-      Map<String, Object> userConfiguration
-  ) {
+  private PipelineElementTemplate getPipelineElementTemplate() {
     var staticProperties = processor
         .declareConfig()
         .getDescription()
@@ -176,7 +170,7 @@ public class ProcessingElementTestExecutor {
     return new PipelineElementTemplate("name", "description", configs);
   }
 
-  private static Event getEvent(Map<String, Object> rawEvent) {
+  private Event getEvent(Map<String, Object> rawEvent) {
 
     // separate the prefix and remove it from the map
     Map<String, Object> eventMap = new HashMap<>(rawEvent);

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/sdt/TestSwingingDoorTrendingFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/sdt/TestSwingingDoorTrendingFilterProcessor.java
@@ -28,6 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 public class TestSwingingDoorTrendingFilterProcessor {
 
@@ -81,7 +84,9 @@ public class TestSwingingDoorTrendingFilterProcessor {
                 sdtValueField, 800.0)
     );
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    testExecutor.run(inputEvents, outputEvents);
   }
 
   @Test
@@ -98,10 +103,17 @@ public class TestSwingingDoorTrendingFilterProcessor {
 
     List<Map<String, Object>> outputEvents = new ArrayList<>();
 
-    Exception exception = new SpRuntimeException("Compression Deviation should be positive!");
+    Exception expectedException = new SpRuntimeException("Compression Deviation should be positive!");
 
-    ProcessingElementTestExecutor
-        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    Exception exception = assertThrows(expectedException.getClass(), () -> {
+      testExecutor.run(inputEvents, outputEvents);
+    });
+    String expectedMessage = expectedException.getMessage();
+    String actualMessage = exception.getMessage();
+    assertTrue(actualMessage.contains(expectedMessage));
+
   }
 
   @Test
@@ -118,10 +130,16 @@ public class TestSwingingDoorTrendingFilterProcessor {
 
     List<Map<String, Object>> outputEvents = new ArrayList<>();
 
-    Exception exception = new SpRuntimeException("Compression Minimum Time Interval should be >= 0!");
+    Exception expectedException = new SpRuntimeException("Compression Minimum Time Interval should be >= 0!");
 
-    ProcessingElementTestExecutor
-        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    Exception exception = assertThrows(expectedException.getClass(), () -> {
+      testExecutor.run(inputEvents, outputEvents);
+    });
+    String expectedMessage = expectedException.getMessage();
+    String actualMessage = exception.getMessage();
+    assertTrue(actualMessage.contains(expectedMessage));
   }
 
   @Test
@@ -138,10 +156,16 @@ public class TestSwingingDoorTrendingFilterProcessor {
 
     List<Map<String, Object>> outputEvents = new ArrayList<>();
 
-    Exception exception = new
+    Exception expectedException = new
         SpRuntimeException("Compression Minimum Time Interval should be < Compression Maximum Time Interval!");
 
-    ProcessingElementTestExecutor
-        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    Exception exception = assertThrows(expectedException.getClass(), () -> {
+      testExecutor.run(inputEvents, outputEvents);
+    });
+    String expectedMessage = expectedException.getMessage();
+    String actualMessage = exception.getMessage();
+    assertTrue(actualMessage.contains(expectedMessage));
   }
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/sdt/TestSwingingDoorTrendingFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/sdt/TestSwingingDoorTrendingFilterProcessor.java
@@ -18,133 +18,130 @@
 
 package org.apache.streampipes.processors.filters.jvm.processor.sdt;
 
-//@RunWith(Parameterized.class)
+import org.apache.streampipes.commons.exceptions.SpRuntimeException;
+import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
 public class TestSwingingDoorTrendingFilterProcessor {
-//
-//  private static final Logger LOG = LoggerFactory.getLogger(TestSwingingDoorTrendingFilterProcessor.class);
-//
-//  @org.junit.runners.Parameterized.Parameter
-//  public String testName;
-//  @org.junit.runners.Parameterized.Parameter(1)
-//  public String sdtCompressionDeviation;
-//  @org.junit.runners.Parameterized.Parameter(2)
-//  public String sdtCompressionMinTimeInterval;
-//  @org.junit.runners.Parameterized.Parameter(3)
-//  public String sdtCompressionMaxTimeInterval;
-//  @org.junit.runners.Parameterized.Parameter(4)
-//  public int expectedFilteredCount;
-//  @org.junit.runners.Parameterized.Parameter(5)
-//  public List<Pair<Long, Double>> eventSettings;
-//  @org.junit.runners.Parameterized.Parameter(6)
-//  public boolean expectException;
-//  @org.junit.runners.Parameterized.Parameter(7)
-//  public String expectedErrorMessage;
-//
-//  private final String sdtTimestampField = "sdtTimestampField";
-//  private final String sdtValueField = "sdtValueField";
-//
-//  @org.junit.runners.Parameterized.Parameters
-//  public static Iterable<Object[]> data() {
-//
-//    return Arrays.asList(new Object[][]{
-//            {"testWithOneEvent", "10.0", "100", "500", 1, List.of(Pair.of(9, 50.0)), false, ""},
-//            {"testFullFilter", "10.0", "100", "500", 4, List.of(
-//                            Pair.of(0, 50.0),      //true
-//                            Pair.of(50, 50.0),     //false
-//                            Pair.of(200, 100.0),   //false
-//                            Pair.of(270, 140.0),   //false
-//                            Pair.of(300, 250.0),   //true
-//                            Pair.of(900, 500.0),   //true
-//                            Pair.of(1100, 800.0),  //false
-//                            Pair.of(1250, 1600.0)  //true
-//            )
-//                    , false, ""},
-//            {"testWithNegativeCompressionDeviation", "-10.0", "100", "500", 1, new ArrayList<>(), true
-//                    , "Compression Deviation should be positive!"},
-//            {"testWithNegativeMinInterval", "10.0", "-100", "500", 1, new ArrayList<>(), true
-//                    , "Compression Minimum Time Interval should be >= 0!"},
-//            {"testWithMinInterval>MaxInterval", "10.0", "1000", "500", 1, new ArrayList<>(), true
-//                    , "Compression Minimum Time Interval should be < Compression Maximum Time Interval!"}
-//    });
-//  }
-//
-//  @Rule
-//  public ExpectedException exceptionRule = ExpectedException.none();
-//
-//  @Test
-//  public void testSdtFilter() {
-//    LOG.info("Executing test: {}", testName);
-//    SwingingDoorTrendingFilterProcessor processor = new SwingingDoorTrendingFilterProcessor();
-//    DataProcessorDescription originalGraph = processor.declareModel();
-//    originalGraph.setSupportedGrounding(EventGroundingGenerator.makeDummyGrounding());
-//
-//    DataProcessorInvocation graph =
-//            InvocationGraphGenerator.makeEmptyInvocation(originalGraph);
-//
-//    ProcessorParams params = new ProcessorParams(graph);
-//    params.extractor().getStaticPropertyByName(SwingingDoorTrendingFilterProcessor.SDT_TIMESTAMP_FIELD_KEY
-//                    , MappingPropertyUnary.class)
-//            .setSelectedProperty("test::" + sdtTimestampField);
-//    params.extractor().getStaticPropertyByName(SwingingDoorTrendingFilterProcessor.SDT_VALUE_FIELD_KEY
-//                    , MappingPropertyUnary.class)
-//            .setSelectedProperty("test::" + sdtValueField);
-//    params.extractor().getStaticPropertyByName(SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_DEVIATION_KEY
-//                    , FreeTextStaticProperty.class)
-//            .setValue(sdtCompressionDeviation);
-//    params.extractor().getStaticPropertyByName(SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MIN_INTERVAL_KEY
-//                    , FreeTextStaticProperty.class)
-//            .setValue(sdtCompressionMinTimeInterval);
-//    params.extractor().getStaticPropertyByName(SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MAX_INTERVAL_KEY
-//                    , FreeTextStaticProperty.class)
-//            .setValue(sdtCompressionMaxTimeInterval);
-//
-//    if (expectException){
-//      LOG.info("Expecting Error Message: {}", expectedErrorMessage);
-//      exceptionRule.expect(SpRuntimeException.class);
-//      exceptionRule.expectMessage(expectedErrorMessage);
-//    }
-//
-//    StoreEventCollector eventCollector = new StoreEventCollector();
-//    processor.onInvocation(params, eventCollector, null);
-//
-//    int result = sendEvents(processor, eventCollector);
-//
-//    LOG.info("Expected SDT filtered count is: {}", expectedFilteredCount);
-//    LOG.info("Actual SDT filtered count is: {}", result);
-//    assertEquals(expectedFilteredCount, result);
-//  }
-//
-//
-//  private int sendEvents(SwingingDoorTrendingFilterProcessor processor, StoreEventCollector collector) {
-//    List<Event> events = makeEvents();
-//    for (Event event : events) {
-//      LOG.info("Sending event with timestamp: "
-//              + event.getFieldBySelector("test::" + sdtTimestampField).getAsPrimitive().getAsLong()
-//              + ", and value: "
-//              + event.getFieldBySelector("test::" + sdtValueField).getAsPrimitive().getAsFloat());
-//      processor.onEvent(event, collector);
-//      try {
-//        Thread.sleep(100);
-//      } catch (InterruptedException e) {
-//        e.printStackTrace();
-//      }
-//    }
-//    return collector.getEvents().size();
-//  }
-//
-//  private List<Event> makeEvents() {
-//    List<Event> events = new ArrayList<>();
-//    for (Pair<Long, Double> eventSetting: eventSettings) {
-//      events.add(makeEvent(eventSetting));
-//    }
-//    return events;
-//  }
-//
-//  private Event makeEvent(Pair<Long, Double> eventSetting) {
-//    Map<String, Object> map = new HashMap<>();
-//    map.put(sdtTimestampField, eventSetting.getKey());
-//    map.put(sdtValueField, eventSetting.getValue());
-//    return EventFactory.fromMap(map, new SourceInfo("test" + "-topic", "test"),
-//            new SchemaInfo(null, new ArrayList<>()));
-//  }
+
+  private final String sdtTimestampField = "sdtTimestampField";
+  private final String sdtValueField = "sdtValueField";
+
+  private SwingingDoorTrendingFilterProcessor processor;
+
+  @BeforeEach
+  public void setup() {
+    processor = new SwingingDoorTrendingFilterProcessor();
+  }
+
+  @Test
+  public void test(){
+    Map<String, Object> userConfiguration = Map.of(
+        SwingingDoorTrendingFilterProcessor.SDT_TIMESTAMP_FIELD_KEY, "::" + sdtTimestampField,
+        SwingingDoorTrendingFilterProcessor.SDT_VALUE_FIELD_KEY, "::" + sdtValueField,
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_DEVIATION_KEY, "10.0",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MIN_INTERVAL_KEY, "100",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MAX_INTERVAL_KEY, "500"
+    );
+
+    List<Map<String, Object>> inputEvents = List.of(
+        Map.of(sdtTimestampField, 0,
+            sdtValueField, 50.0),
+        Map.of(sdtTimestampField, 50,
+            sdtValueField, 50.0),
+        Map.of(sdtTimestampField, 200,
+            sdtValueField, 100.0),
+        Map.of(sdtTimestampField, 270,
+            sdtValueField, 140.0),
+        Map.of(sdtTimestampField, 300,
+            sdtValueField, 250.0),
+        Map.of(sdtTimestampField, 900,
+            sdtValueField, 500.0),
+        Map.of(sdtTimestampField, 1100,
+            sdtValueField, 800.0),
+        Map.of(sdtTimestampField, 1250,
+            sdtValueField, 1600.0)
+    );
+
+    List<Map<String, Object>> outputEvents = List.of(
+            Map.of(sdtTimestampField, 0,
+                sdtValueField, 50.0),
+            Map.of(sdtTimestampField, 270,
+                sdtValueField, 140.0),
+            Map.of(sdtTimestampField, 900,
+                sdtValueField, 500.0),
+            Map.of(sdtTimestampField, 1100,
+                sdtValueField, 800.0)
+    );
+
+    ProcessingElementTestExecutor.run(processor, userConfiguration, inputEvents, outputEvents, null);
+  }
+
+  @Test
+  public void testInvalidDeviationKey(){
+    Map<String, Object> userConfiguration = Map.of(
+        SwingingDoorTrendingFilterProcessor.SDT_TIMESTAMP_FIELD_KEY, "::" + sdtTimestampField,
+        SwingingDoorTrendingFilterProcessor.SDT_VALUE_FIELD_KEY, "::" + sdtValueField,
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_DEVIATION_KEY, "-10.0",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MIN_INTERVAL_KEY, "100",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MAX_INTERVAL_KEY, "500"
+    );
+
+    List<Map<String, Object>> inputEvents = new ArrayList<>();
+
+    List<Map<String, Object>> outputEvents = new ArrayList<>();
+
+    Exception exception = new SpRuntimeException("Compression Deviation should be positive!");
+
+    ProcessingElementTestExecutor
+        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+  }
+
+  @Test
+  public void testNegativeMinimumTime(){
+    Map<String, Object> userConfiguration = Map.of(
+        SwingingDoorTrendingFilterProcessor.SDT_TIMESTAMP_FIELD_KEY, "::" + sdtTimestampField,
+        SwingingDoorTrendingFilterProcessor.SDT_VALUE_FIELD_KEY, "::" + sdtValueField,
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_DEVIATION_KEY, "10.0",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MIN_INTERVAL_KEY, "-100",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MAX_INTERVAL_KEY, "500"
+    );
+
+    List<Map<String, Object>> inputEvents = new ArrayList<>();
+
+    List<Map<String, Object>> outputEvents = new ArrayList<>();
+
+    Exception exception = new SpRuntimeException("Compression Minimum Time Interval should be >= 0!");
+
+    ProcessingElementTestExecutor
+        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+  }
+
+  @Test
+  public void testInvalidTimeInterval(){
+    Map<String, Object> userConfiguration = Map.of(
+        SwingingDoorTrendingFilterProcessor.SDT_TIMESTAMP_FIELD_KEY, "::" + sdtTimestampField,
+        SwingingDoorTrendingFilterProcessor.SDT_VALUE_FIELD_KEY, "::" + sdtValueField,
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_DEVIATION_KEY, "10.0",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MIN_INTERVAL_KEY, "1000",
+        SwingingDoorTrendingFilterProcessor.SDT_COMPRESSION_MAX_INTERVAL_KEY, "500"
+    );
+
+    List<Map<String, Object>> inputEvents = new ArrayList<>();
+
+    List<Map<String, Object>> outputEvents = new ArrayList<>();
+
+    Exception exception = new
+        SpRuntimeException("Compression Minimum Time Interval should be < Compression Maximum Time Interval!");
+
+    ProcessingElementTestExecutor
+        .runWithException(processor, userConfiguration, inputEvents, outputEvents, null, exception);
+  }
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/textfilter/TestTextFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/textfilter/TestTextFilterProcessor.java
@@ -18,101 +18,99 @@
 
 package org.apache.streampipes.processors.filters.jvm.processor.textfilter;
 
-//@RunWith(Parameterized.class)
+import org.apache.streampipes.processors.filters.jvm.processor.numericalfilter.ProcessingElementTestExecutor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+
 public class TestTextFilterProcessor {
 
-//  private static final Logger LOG = LoggerFactory.getLogger(TestTextFilterProcessor.class);
-//
-//  @org.junit.runners.Parameterized.Parameters
-//  public static Iterable<Object[]> data() {
-//    return Arrays.asList(new Object[][] {
-//        {"TestLowerCaseMatch", "keyword", StringOperator.MATCHES, Arrays.asList("keyword", "KeyWord", "KEYWORD"), 1},
-//        {"TestUpperCaseMatch", "KEYWORD", StringOperator.MATCHES, Arrays.asList("keyword", "KeyWord", "KEYWORD"), 1},
-//        {"TestMixMatch", "KeyWord", StringOperator.MATCHES, Arrays.asList("keyword", "KeyWord", "KEYWORD"), 1},
-//        {"TestEmptyMatch", "keYWord", StringOperator.MATCHES, Arrays.asList("keyword", "KeyWord", "KEYWORD"), 0},
-//        {"TestMultipleMatch", "KeyWord", StringOperator.MATCHES,
-//            Arrays.asList("keyword", "KeyWord", "KEYWORD", "KeyWord"), 2},
-//
-//        {"TestContainsWord", "keyword", StringOperator.CONTAINS,
-//            Arrays.asList("text contains keyword", "text doesn't have word"), 1},
-//        {"TestNotContainsWord", "keyword", StringOperator.CONTAINS,
-//            Arrays.asList("text is empty", "text doesn't have word"), 0},
-//    });
-//  }
-//
-//  @org.junit.runners.Parameterized.Parameter
-//  public String selectedFieldName;
-//
-//  @org.junit.runners.Parameterized.Parameter(1)
-//  public String keyword;
-//
-//  @org.junit.runners.Parameterized.Parameter(2)
-//  public StringOperator stringOperator;
-//
-//  @org.junit.runners.Parameterized.Parameter(3)
-//  public List<String> eventStrings;
-//
-//  @org.junit.runners.Parameterized.Parameter(4)
-//  public int expectedFilteredTextCount;
-//
-//  @Test
-//  public void testTextFilter() {
-//    TextFilterProcessor textFilterProcessor = new TextFilterProcessor();
-//    DataProcessorDescription originalGraph = textFilterProcessor.declareModel();
-//    originalGraph.setSupportedGrounding(EventGroundingGenerator.makeDummyGrounding());
-//
-//    DataProcessorInvocation graph = InvocationGraphGenerator.makeEmptyInvocation(originalGraph);
-//    graph.setInputStreams(Collections
-//        .singletonList(EventStreamGenerator
-//            .makeStreamWithProperties(Collections.singletonList(selectedFieldName))));
-//    graph.setOutputStream(EventStreamGenerator
-//    .makeStreamWithProperties(Collections.singletonList(selectedFieldName)));
-//    graph.getOutputStream().getEventGrounding().getTransportProtocol().getTopicDefinition()
-//        .setActualTopicName("output-topic");
-//
-//    graph.getStaticProperties().stream()
-//        .filter(p -> p instanceof MappingPropertyUnary)
-//        .map(p -> (MappingPropertyUnary) p)
-//        .filter(p -> p.getInternalName().equals(TextFilterProcessor.MAPPING_PROPERTY_ID))
-//        .findFirst().get().setSelectedProperty("s0::" + selectedFieldName);
-//    ProcessorParams params = new ProcessorParams(graph);
-//    params.extractor().getStaticPropertyByName(TextFilterProcessor.OPERATION_ID, OneOfStaticProperty.class)
-//        .getOptions()
-//        .stream().filter(o -> o.getName().equals(stringOperator.name())).findFirst().get().setSelected(true);
-//    params.extractor().getStaticPropertyByName(TextFilterProcessor.KEYWORD_ID, FreeTextStaticProperty.class)
-//        .setValue(keyword);
-//    StoreEventCollector collector = new StoreEventCollector();
-//
-//    textFilterProcessor.onInvocation(params, collector, null);
-//    int result = sendEvents(textFilterProcessor, collector);
-//
-//    LOG.info("Expected filtered text count is {}", expectedFilteredTextCount);
-//    LOG.info("Actual filtered text count is {}", result);
-//    assertEquals(expectedFilteredTextCount, result);
-//
-//  }
-//
-//  private int sendEvents(TextFilterProcessor textFilterProcessor, StoreEventCollector collector) {
-//    List<Event> events = makeEvents();
-//    for (Event e : events) {
-//      textFilterProcessor.onEvent(e, collector);
-//    }
-//    return collector.getEvents().size();
-//  }
-//
-//  private List<Event> makeEvents() {
-//    List<Event> events = new ArrayList<>();
-//    for (String eventString : eventStrings) {
-//      events.add(makeEvent(eventString));
-//    }
-//    return events;
-//  }
-//
-//  private Event makeEvent(String eventString) {
-//    Map<String, Object> map = Maps.newHashMap();
-//    map.put(selectedFieldName, eventString);
-//    return EventFactory.fromMap(map,
-//        new SourceInfo("test", "s0"),
-//        new SchemaInfo(null, Lists.newArrayList()));
-//  }
+  TextFilterProcessor processor;
+
+  public static final String FIELD_NAME = "selectedField";
+  public static final String FIELD_NAME_WITH_PREFIX = "s0::" + FIELD_NAME;
+
+  @BeforeEach
+  public void setup(){
+    processor = new TextFilterProcessor();
+  }
+
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(String keyword,
+                   StringOperator stringOperator,
+                   List<String> eventValues,
+                   List<String> outputEventValues){
+
+    Map<String, Object> userConfiguration =
+        Map.of(
+            TextFilterProcessor.MAPPING_PROPERTY_ID, FIELD_NAME_WITH_PREFIX,
+            TextFilterProcessor.OPERATION_ID, stringOperator,
+            TextFilterProcessor.KEYWORD_ID, keyword
+        );
+
+    List<Map<String, Object>> events = new ArrayList<>();
+    eventValues.forEach(value->events.add(Map.of(FIELD_NAME_WITH_PREFIX, value)));
+
+    List<Map<String, Object>> outputEvents = new ArrayList<>();
+    outputEventValues.forEach(value->outputEvents.add(Map.of(FIELD_NAME, value)));
+
+    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, null);
+  }
+
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
+            "keyword",
+            StringOperator.MATCHES,
+            List.of("keyword", "KeyWord", "KEYWORD"),
+            List.of("keyword")
+        ),
+        Arguments.of(
+            "KEYWORD",
+            StringOperator.MATCHES,
+            List.of("keyword", "KeyWord", "KEYWORD"),
+            List.of("KEYWORD")
+        ),
+        Arguments.of(
+            "KeyWord",
+            StringOperator.MATCHES,
+            List.of("keyword", "KeyWord", "KEYWORD"),
+            List.of("KeyWord")
+        ),
+        Arguments.of(
+            "keYWord",
+            StringOperator.MATCHES,
+            List.of("keyword", "KeyWord", "KEYWORD"),
+            List.of()
+        ),
+        Arguments.of(
+            "KeyWord",
+            StringOperator.MATCHES,
+            List.of("keyword", "KeyWord", "KEYWORD", "KeyWord"),
+            List.of("KeyWord", "KeyWord")
+        ),
+        Arguments.of(
+            "keyword",
+            StringOperator.CONTAINS,
+            List.of("text contains keyword", "text doesn't have word"),
+            List.of("text contains keyword")
+        ),
+        Arguments.of(
+            "keyword",
+            StringOperator.CONTAINS,
+            List.of("text is empty", "text doesn't have word"),
+            List.of()
+        )
+    );
+  }
 }

--- a/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/textfilter/TestTextFilterProcessor.java
+++ b/streampipes-extensions/streampipes-processors-filters-jvm/src/test/java/org/apache/streampipes/processors/filters/jvm/processor/textfilter/TestTextFilterProcessor.java
@@ -63,7 +63,9 @@ public class TestTextFilterProcessor {
     List<Map<String, Object>> outputEvents = new ArrayList<>();
     outputEventValues.forEach(value->outputEvents.add(Map.of(FIELD_NAME, value)));
 
-    ProcessingElementTestExecutor.run(processor, userConfiguration, events, outputEvents, null);
+    ProcessingElementTestExecutor testExecutor = new ProcessingElementTestExecutor(processor, userConfiguration);
+
+    testExecutor.run(events, outputEvents);
   }
 
 


### PR DESCRIPTION

Added a couple of features to the test executor.

1. Option to provide custom configuration. TestComposeProcessor required to set output strategies and TestMergeByTimeProcessor required to set output key selectors.
2. Mocked mockParams.getModel(). Required for processors of type StreamPipesDataProcessor, which generate their own extractor based on the graph provided
3. Updated event creation to detect the prefix in the map keys and parse it properly

Refactored all tests in streampipes-processors-filters-jvm to use the executor
 
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
