### PR TITLE
fix: Fix client python docs site build warning

### DIFF
--- a/streampipes-client-python/streampipes/client/credential_provider.py
+++ b/streampipes-client-python/streampipes/client/credential_provider.py
@@ -81,7 +81,7 @@ class CredentialProvider(ABC):
 class StreamPipesApiKeyCredentials(CredentialProvider):
     """A credential provider that allows authentication via a StreamPipes API Token.
 
-    The required token can be generated via the StreamPipes UI (see the description on our [start-page](../../../).
+    The required token can be generated via the StreamPipes UI (see the description on our [start-page](../../index.md).
 
     Both parameters can either be passed as arguments or remain unset.
     If they are not passed, they are retrieved from environment variables:

--- a/streampipes-client-python/streampipes/model/resource/function_definition.py
+++ b/streampipes-client-python/streampipes/model/resource/function_definition.py
@@ -34,7 +34,7 @@ class FunctionId(BasicModel):
 
     Maps to the `FunctionId` class defined in the StreamPipes model.
 
-    Parameters
+    Attributes
     ----------
     id: str
         unique identifier of the function instance
@@ -56,15 +56,12 @@ class FunctionDefinition(Resource):
     This class maps to the `FunctionDefinition` class in the StreamPipes model.
     It contains all metadata that are required to register a function at the StreamPipes backend.
 
-    Parameters
+    Attributes
     ----------
     consumed_streams: List[str]
         List of data streams the function is consuming from
     function_id: FunctionId
         identifier object of a StreamPipes function
-
-    Attributes
-    ----------
     output_data_streams: Dict[str, DataStream]
         Map off all output data streams added to the function definition
 


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
While building the StreamPipes client python documentation site locally, I noticed several warnings being logged in the console. I made adjustments to the relevant sections of the code to eliminate these warnings.

I have also reviewed the issues tagged with `documentation` or `website` and found no existing issues related to these warnings, ensuring that this PR does not duplicate any previously reported issues.

Detailed console output:

```
INFO    -  Doc file 'reference/client/credential_provider.md' contains an unrecognized relative link '../../../', it was
           left as is. Did you mean '../../index.md'?
WARNING -  griffe: streampipes\model\resource\function_definition.py:65: No types or annotations for parameters
           ['consumed_streams']
WARNING -  griffe: streampipes\model\resource\function_definition.py:65: Parameter 'consumed_streams' does not appear in
           the function signature
WARNING -  griffe: streampipes\model\resource\function_definition.py:65: No types or annotations for parameters
           ['function_id']
WARNING -  griffe: streampipes\model\resource\function_definition.py:65: Parameter 'function_id' does not appear in the
           function signature
WARNING -  griffe: streampipes\model\resource\function_definition.py:42: No types or annotations for parameters ['id']
WARNING -  griffe: streampipes\model\resource\function_definition.py:42: Parameter 'id' does not appear in the function
           signature
WARNING -  griffe: streampipes\model\resource\function_definition.py:42: No types or annotations for parameters
           ['version']
WARNING -  griffe: streampipes\model\resource\function_definition.py:42: Parameter 'version' does not appear in the
           function signature
```

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): <yes/no>
no
PR introduces (a) deprecation(s): <yes/no>
no