### PR TITLE
fix: Replace deprecated assertDictContainsSubset in python client unit tests

### DIFF
--- a/streampipes-client-python/tests/client/test_client.py
+++ b/streampipes-client-python/tests/client/test_client.py
@@ -44,10 +44,8 @@ class TestStreamPipesClient(TestCase):
             "Application": "application/json",
         }
         result_headers = dict(result.request_session.headers)
-        self.assertDictContainsSubset(
-            subset=expected_headers,
-            dictionary=result_headers,
-        )
+        for key, value in expected_headers.items():
+            self.assertEqual(result_headers.get(key), value)
         self.assertTrue(isinstance(result.dataLakeMeasureApi, DataLakeMeasureEndpoint))
         self.assertEqual(result.base_api_path, "http://localhost:80/streampipes-backend/")
 
@@ -71,10 +69,8 @@ class TestStreamPipesClient(TestCase):
             "Application": "application/json",
         }
         result_headers = dict(result.request_session.headers)
-        self.assertDictContainsSubset(
-            subset=expected_headers,
-            dictionary=result_headers,
-        )
+        for key, value in expected_headers.items():
+            self.assertEqual(result_headers.get(key), value)
         self.assertTrue(isinstance(result.dataLakeMeasureApi, DataLakeMeasureEndpoint))
         self.assertEqual(result.base_api_path, "https://localhost:443/streampipes-backend/")
 


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->
  
  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar. 
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

Replace deprecated `assertDictContainsSubset` in python client unit tests.

Part of the console output `warnings summary` is:

```
tests/client/test_client.py::TestStreamPipesClient::test_client_create
  C:\Users\...\streampipes-dev\streampipes-client-python\tests\client\test_client.py:74: DeprecationWarning: assertDictContainsSubset is deprecated
    self.assertDictContainsSubset(

tests/client/test_client.py::TestStreamPipesClient::test_client_init
  C:\Users\...\streampipes-dev\streampipes-client-python\tests\client\test_client.py:47: DeprecationWarning: assertDictContainsSubset is deprecated
    self.assertDictContainsSubset(
```

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): <yes/no>
no
PR introduces (a) deprecation(s): <yes/no>
no