### PR TITLE
chore: cli installer switch to compose v2 api

### DIFF
--- a/installer/cli/bin/common
+++ b/installer/cli/bin/common
@@ -69,8 +69,8 @@ deployment_notice() {
 
     If your environment contains the StreamPipes UI, open your browser and follow
     the instructions to get started:
-    
-    Local Docker for Mac/Windows, Linux:     http://localhost/   
+
+    Local Docker for Mac/Windows, Linux:     http://localhost/
     Remote Docker host:                      http://HOST_IP/
 
 EOF
@@ -110,7 +110,7 @@ get_curr_environment() {
 concatenate_compose_files() {
   no_ports=$1
   search_str="[environment:"
-  docker_compose_files="docker-compose --env-file $STREAMPIPES_WORKDIR/.env"
+  docker_compose_files="docker compose --env-file $STREAMPIPES_WORKDIR/.env"
 
   while IFS='' read -r line; do
     [[ -n "$line" && "$line" != *"$search_str"* && "$line" != [[:blank:]#]* ]] &&


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->


### Purpose
Hey thanks for providing this awesome piece of software.
While installing with the `cli-installer` I stumbled upon a legacy usage of `docker-compose` which broke on my system. 
https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

This tiny pr fixes the issue. 

