### PR TITLE
2354 harmonize influx store and influx db client

### DIFF
--- a/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/TimeSeriesStorageInflux.java
+++ b/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/TimeSeriesStorageInflux.java
@@ -45,7 +45,7 @@ public class TimeSeriesStorageInflux extends TimeSeriesStorage {
       InfluxClientProvider influxClientProvider
   ) throws SpRuntimeException {
     super(measure);
-    influxDb = influxClientProvider.getInitializedInfluxDBClient(environment);
+    this.influxDb = influxClientProvider.getSetUpInfluxDBClient(environment);
     propertyHandler = new PropertyHandler();
   }
 

--- a/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
+++ b/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
@@ -39,7 +39,7 @@ public class InfluxClientProvider {
   /**
    * Create a new InfluxDB client from Environment and ensures database is available
    * @param environment Environment
-   * @return
+   * @return InfluxDB
    */
   public InfluxDB getSetUpInfluxDBClient(Environment environment){
     return getSetUpInfluxDBClient(InfluxConnectionSettings.from(environment));
@@ -48,7 +48,7 @@ public class InfluxClientProvider {
   /**
    * Create a new InfluxDB client from Connection Settings and ensures database is available
    * @param settings Connection Settings
-   * @return
+   * @return InfluxDB
    */
   public InfluxDB getSetUpInfluxDBClient(InfluxConnectionSettings settings){
     var influxDb = getInitializedInfluxDBClient(settings);

--- a/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
+++ b/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
 
 public class InfluxClientProvider {
 
+  private static final int DEFAULT_BATCH_SIZE = 2000;
+  private static final int DEFAULT_FLUSH_DURATION = 500;
+
   private static final Logger LOG = LoggerFactory.getLogger(InfluxClientProvider.class);
 
   /**
@@ -108,16 +111,16 @@ public class InfluxClientProvider {
   }
 
   /**
-   * Creates the specified database in the influxDb instance if it does not exists. Enables batching with default values
+   * Creates the specified database in the influxDb instance if it does not exist. Enables batching with default values
    * @param influxDb The InfluxDB client instance
    * @param databaseName The name of the database
    */
   public void setupDatabaseAndBatching(InfluxDB influxDb, String databaseName) {
-    this.setupDatabaseAndBatching(influxDb, databaseName, 2000, 500);
+    this.setupDatabaseAndBatching(influxDb, databaseName, DEFAULT_BATCH_SIZE, DEFAULT_FLUSH_DURATION);
   }
 
   /**
-   * Creates the specified database in the influxDb instance if it does not exists. Enables batching
+   * Creates the specified database in the influxDb instance if it does not exist. Enables batching
    * @param influxDb The InfluxDB client instance
    * @param databaseName The name of the database
    * @param batchSize Batch Size

--- a/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
+++ b/streampipes-data-explorer-influx/src/main/java/org/apache/streampipes/dataexplorer/influx/client/InfluxClientProvider.java
@@ -36,9 +36,20 @@ public class InfluxClientProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(InfluxClientProvider.class);
 
+  /**
+   * Create a new InfluxDB client from Environment and ensures database is available
+   * @param environment Environment
+   * @return
+   */
   public InfluxDB getSetUpInfluxDBClient(Environment environment){
     return getSetUpInfluxDBClient(InfluxConnectionSettings.from(environment));
   }
+
+  /**
+   * Create a new InfluxDB client from Connection Settings and ensures database is available
+   * @param settings Connection Settings
+   * @return
+   */
   public InfluxDB getSetUpInfluxDBClient(InfluxConnectionSettings settings){
     var influxDb = getInitializedInfluxDBClient(settings);
     this.setupDatabaseAndBatching(influxDb, settings.getDatabaseName());
@@ -96,11 +107,22 @@ public class InfluxClientProvider {
     }
   }
 
+  /**
+   * Creates the specified database in the influxDb instance if it does not exists. Enables batching with default values
+   * @param influxDb The InfluxDB client instance
+   * @param databaseName The name of the database
+   */
   public void setupDatabaseAndBatching(InfluxDB influxDb, String databaseName) {
     this.setupDatabaseAndBatching(influxDb, databaseName, 2000, 500);
   }
 
-
+  /**
+   * Creates the specified database in the influxDb instance if it does not exists. Enables batching
+   * @param influxDb The InfluxDB client instance
+   * @param databaseName The name of the database
+   * @param batchSize Batch Size
+   * @param flushDuration Flush Duration
+   */
   public void setupDatabaseAndBatching(InfluxDB influxDb, String databaseName, int batchSize, int flushDuration) {
     // Checking whether the database exists
     if (!databaseExists(influxDb, databaseName)) {

--- a/streampipes-data-explorer-influx/src/test/java/org/apache/streampipes/dataexplorer/influx/TimeSeriesStorageInfluxTest.java
+++ b/streampipes-data-explorer-influx/src/test/java/org/apache/streampipes/dataexplorer/influx/TimeSeriesStorageInfluxTest.java
@@ -19,6 +19,7 @@
 package org.apache.streampipes.dataexplorer.influx;
 
 
+import org.apache.streampipes.commons.environment.Environment;
 import org.apache.streampipes.commons.exceptions.SpRuntimeException;
 import org.apache.streampipes.dataexplorer.influx.client.InfluxClientProvider;
 import org.apache.streampipes.model.datalake.DataLakeMeasure;
@@ -383,7 +384,7 @@ public class TimeSeriesStorageInfluxTest {
     );
 
     var influxClientProviderMock = Mockito.mock(InfluxClientProvider.class);
-    Mockito.when(influxClientProviderMock.getInitializedInfluxDBClient(ArgumentMatchers.any()))
+    Mockito.when(influxClientProviderMock.getSetUpInfluxDBClient((Environment) ArgumentMatchers.any()))
            .thenReturn(influxDBMock);
 
     return new TimeSeriesStorageInflux(measure, null, influxClientProviderMock);

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/adapter/InfluxDbClient.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/adapter/InfluxDbClient.java
@@ -109,7 +109,7 @@ public class InfluxDbClient extends SharedInfluxClient {
 
   public void disconnect() {
     if (connected) {
-      influxDb.close();
+      super.disconnect();
       connected = false;
     }
   }

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/shared/SharedInfluxClient.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/shared/SharedInfluxClient.java
@@ -23,7 +23,6 @@ import org.apache.streampipes.dataexplorer.influx.client.InfluxClientProvider;
 import org.apache.streampipes.dataexplorer.influx.client.InfluxConnectionSettings;
 
 import org.influxdb.InfluxDB;
-import org.influxdb.dto.Pong;
 
 public abstract class SharedInfluxClient {
 
@@ -42,12 +41,14 @@ public abstract class SharedInfluxClient {
 
 
   protected void initClient() throws SpRuntimeException {
-    this.influxDb = InfluxClientProvider.getInfluxDBClient(connectionSettings);
+    InfluxClientProvider influxClientProvider = new InfluxClientProvider();
+    this.influxDb = influxClientProvider.getInitializedInfluxDBClient(connectionSettings);
+  }
 
-    // Checking, if server is available
-    Pong response = influxDb.ping();
-    if (response.getVersion().equalsIgnoreCase("unknown")) {
-      throw new SpRuntimeException("Could not connect to InfluxDb Server: " + connectionSettings.getConnectionUrl());
-    }
+  /**
+   * Shuts down the connection to the InfluxDB server
+   */
+  public void disconnect() {
+    influxDb.close();
   }
 }

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
@@ -25,8 +25,6 @@ import org.apache.streampipes.extensions.connectors.influx.shared.SharedInfluxCl
 import org.apache.streampipes.model.runtime.Event;
 
 import org.influxdb.dto.Point;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 
 public class InfluxDbClient extends SharedInfluxClient {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InfluxDbClient.class);
 
   private final String timestampField;
   private final Integer batchSize;

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbClient.java
@@ -24,7 +24,6 @@ import org.apache.streampipes.dataexplorer.influx.client.InfluxConnectionSetting
 import org.apache.streampipes.extensions.connectors.influx.shared.SharedInfluxClient;
 import org.apache.streampipes.model.runtime.Event;
 
-import org.influxdb.BatchOptions;
 import org.influxdb.dto.Point;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,17 +65,8 @@ public class InfluxDbClient extends SharedInfluxClient {
    */
   private void connect() throws SpRuntimeException {
     super.initClient();
-    var databaseName = connectionSettings.getDatabaseName();
-
-    // Checking whether the database exists
-    if (!influxClientProvider.databaseExists(influxDb, databaseName)) {
-      LOG.info("Database '" + databaseName + "' not found. Gets created ...");
-      influxClientProvider.createDatabase(influxDb, databaseName);
-    }
-
-    // setting up the database
-    influxDb.setDatabase(databaseName);
-    influxDb.enableBatch(BatchOptions.DEFAULTS.actions(batchSize).flushDuration(flushDuration));
+    influxClientProvider.setupDatabaseAndBatching(
+        influxDb, connectionSettings.getDatabaseName(), batchSize, flushDuration);
   }
 
   /**
@@ -106,12 +96,5 @@ public class InfluxDbClient extends SharedInfluxClient {
     }
 
     influxDb.write(p.build());
-  }
-
-  /**
-   * Shuts down the connection to the InfluxDB server
-   */
-  void stop() {
-    influxDb.close();
   }
 }

--- a/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbSink.java
+++ b/streampipes-extensions/streampipes-connectors-influx/src/main/java/org/apache/streampipes/extensions/connectors/influx/sink/InfluxDbSink.java
@@ -83,7 +83,7 @@ public class InfluxDbSink extends StreamPipesDataSink {
 
   @Override
   public void onDetach() throws SpRuntimeException {
-    influxDbClient.stop();
+    influxDbClient.disconnect();
   }
 
   public static String prepareString(String s) {


### PR DESCRIPTION
### Purpose

Closes #2354. Moved the common functionality to InfluxClientProvider. 

### Remarks

Tested pipelines locally with Data Lake and InfluxDB Data Sinks. For both data ends up in the InfluxDB with no errors.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
