### PR TITLE
[WIP][#3446] Remove nginx default.conf SP 0.93.0 -> 0.95.0 migration code

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,14 +17,6 @@ FROM nginx:mainline-alpine3.18
 
 COPY dist/streampipes/ui/browser/ /usr/share/nginx/html/
 
-#Store a copy to have a version if the other is hidden in the volume. Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
-RUN mkdir -p /etc/opt/nginx/
-RUN chown -R nginx:nginx /etc/opt/nginx/
-COPY nginx_config/default.conf.template /etc/opt/nginx/default.conf.template
-RUN chown -R nginx:nginx  /etc/opt/nginx/default.conf.template
-
-
-
 RUN chown -R nginx:nginx /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html && \
         chown -R nginx:nginx /var/cache/nginx && \
         chown -R nginx:nginx /var/log/nginx && \

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -19,14 +19,6 @@ if [ ! -z "$NGINX_SSL" ] && [ "$NGINX_SSL" = "true" ]; then
     rm /etc/nginx/conf.d/default.conf
     ln -s /app/nginx-confs/ssl.conf /etc/nginx/conf.d/default.conf
 elif [ ! -z "$SP_HTTP_SERVER_ADAPTER_ENDPOINT" ]; then
-
-    if [ ! -f /etc/nginx/conf.d/default.conf ]
-    then
-        DEFAULT_CONF_BACKUP="/etc/nginx/conf.d/default.conf_$(date +%s).bak"
-        echo "Create backup of old configuration $DEFAULT_CONF_BACKUP"
-        cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
-    fi
-
     rm  -f /etc/nginx/conf.d/default.conf
     envsubst '\$SP_HTTP_SERVER_ADAPTER_ENDPOINT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -27,13 +27,6 @@ elif [ ! -z "$SP_HTTP_SERVER_ADAPTER_ENDPOINT" ]; then
         cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
     fi
 
-    # Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
-    if [ ! -f /etc/nginx/conf.d/default.conf.template ]
-    then
-        echo "Migrate to new nginx template"
-        cp /etc/opt/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
-    fi
-
     rm  -f /etc/nginx/conf.d/default.conf
     envsubst '\$SP_HTTP_SERVER_ADAPTER_ENDPOINT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi


### PR DESCRIPTION
Fixes #3446

<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->


### Purpose
Remove obsolete migration code.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
