### PR TITLE
feat: axis labels for 2d charts

### DIFF
--- a/ui/src/app/data-explorer-shared/components/charts/correlation-chart/config/correlation-chart-widget-config.component.html
+++ b/ui/src/app/data-explorer-shared/components/charts/correlation-chart/config/correlation-chart-widget-config.component.html
@@ -46,6 +46,24 @@
                 fxLayoutGap="10px"
                 fxLayoutAlign="start center"
             >
+                <small>{{ 'X Label' | translate }}</small>
+                <mat-form-field appearance="outline" color="accent" fxFlex>
+                    <input
+                        matInput
+                        type="text"
+                        [(ngModel)]="
+                            currentlyConfiguredWidget.visualizationConfig.labelX
+                        "
+                        (ngModelChange)="triggerViewRefresh()"
+                    />
+                </mat-form-field>
+            </div>
+            <div
+                fxLayout="row"
+                fxFlex="100"
+                fxLayoutGap="10px"
+                fxLayoutAlign="start center"
+            >
                 <small>{{ 'Y' | translate }}</small>
                 <sp-select-single-property-config
                     fxFlex
@@ -57,6 +75,24 @@
                     (changeSelectedProperty)="updateSecondField($event)"
                 >
                 </sp-select-single-property-config>
+            </div>
+            <div
+                fxLayout="row"
+                fxFlex="100"
+                fxLayoutGap="10px"
+                fxLayoutAlign="start center"
+            >
+                <small>{{ 'Y Label' | translate }}</small>
+                <mat-form-field appearance="outline" color="accent" fxFlex>
+                    <input
+                        matInput
+                        type="text"
+                        [(ngModel)]="
+                            currentlyConfiguredWidget.visualizationConfig.labelY
+                        "
+                        (ngModelChange)="triggerViewRefresh()"
+                    />
+                </mat-form-field>
             </div>
         </div>
     </sp-configuration-box>

--- a/ui/src/app/data-explorer-shared/components/charts/correlation-chart/model/correlation-chart-widget.model.ts
+++ b/ui/src/app/data-explorer-shared/components/charts/correlation-chart/model/correlation-chart-widget.model.ts
@@ -26,6 +26,8 @@ import { DataExplorerVisConfig } from '../../../../models/dataview-dashboard.mod
 export interface CorrelationChartVisConfig extends DataExplorerVisConfig {
     firstField: DataExplorerField;
     secondField: DataExplorerField;
+    labelX: string;
+    labelY: string;
 }
 
 export interface CorrelationChartWidgetModel extends DataExplorerWidgetModel {

--- a/ui/src/app/data-explorer-shared/components/charts/density/density-renderer.service.ts
+++ b/ui/src/app/data-explorer-shared/components/charts/density/density-renderer.service.ts
@@ -67,7 +67,7 @@ export class SpDensityRendererService extends SpBaseEchartsRenderer<CorrelationC
                 max: Math.ceil(stats.maxX + 1),
                 name:
                     widgetConfig.visualizationConfig.labelX ||
-                    `${xField.fullDbName} (${xField.measurementUnitResourceId ? xField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                    `${xField.fullDbName}${xField.measurementUnitResourceId ? ` (${xField.measurementUnitResourceId.split('#').pop()})` : ''}`,
                 nameLocation: 'center',
                 nameTextStyle: {
                     fontSize: 20,
@@ -79,7 +79,7 @@ export class SpDensityRendererService extends SpBaseEchartsRenderer<CorrelationC
                 max: Math.ceil(stats.maxY + 1),
                 name:
                     widgetConfig.visualizationConfig.labelY ||
-                    `${yField.fullDbName} (${yField.measurementUnitResourceId ? yField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                    `${yField.fullDbName}${yField.measurementUnitResourceId ? ` (${yField.measurementUnitResourceId.split('#').pop()})` : ''}`,
                 nameLocation: 'center',
                 nameTextStyle: {
                     fontSize: 20,

--- a/ui/src/app/data-explorer-shared/components/charts/density/density-renderer.service.ts
+++ b/ui/src/app/data-explorer-shared/components/charts/density/density-renderer.service.ts
@@ -65,11 +65,25 @@ export class SpDensityRendererService extends SpBaseEchartsRenderer<CorrelationC
                 scale: true,
                 min: Math.floor(stats.minX - 1),
                 max: Math.ceil(stats.maxX + 1),
+                name:
+                    widgetConfig.visualizationConfig.labelX ||
+                    `${xField.fullDbName} (${xField.measurementUnitResourceId ? xField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                nameLocation: 'center',
+                nameTextStyle: {
+                    fontSize: 20,
+                },
             },
             yAxis: {
                 scale: true,
                 min: Math.floor(stats.minY - 1),
                 max: Math.ceil(stats.maxY + 1),
+                name:
+                    widgetConfig.visualizationConfig.labelY ||
+                    `${yField.fullDbName} (${yField.measurementUnitResourceId ? yField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                nameLocation: 'center',
+                nameTextStyle: {
+                    fontSize: 20,
+                },
             },
             dataset: dataset.rawDataset,
             visualMap: {

--- a/ui/src/app/data-explorer-shared/components/charts/scatter/scatter-renderer.service.ts
+++ b/ui/src/app/data-explorer-shared/components/charts/scatter/scatter-renderer.service.ts
@@ -68,7 +68,7 @@ export class SpScatterRendererService extends SpBaseEchartsRenderer<CorrelationC
                 max: 'dataMax',
                 name:
                     widgetConfig.visualizationConfig.labelX ||
-                    `${xField.fullDbName} (${xField.measurementUnitResourceId ? xField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                    `${xField.fullDbName}${xField.measurementUnitResourceId ? ` (${xField.measurementUnitResourceId.split('#').pop()})` : ''}`,
                 nameLocation: 'center',
                 nameTextStyle: {
                     fontSize: 20,
@@ -80,7 +80,7 @@ export class SpScatterRendererService extends SpBaseEchartsRenderer<CorrelationC
                 max: 'dataMax',
                 name:
                     widgetConfig.visualizationConfig.labelY ||
-                    `${yField.fullDbName} (${yField.measurementUnitResourceId ? yField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                    `${yField.fullDbName}${yField.measurementUnitResourceId ? ` (${yField.measurementUnitResourceId.split('#').pop()})` : ''}`,
                 nameLocation: 'center',
                 nameTextStyle: {
                     fontSize: 20,

--- a/ui/src/app/data-explorer-shared/components/charts/scatter/scatter-renderer.service.ts
+++ b/ui/src/app/data-explorer-shared/components/charts/scatter/scatter-renderer.service.ts
@@ -66,11 +66,25 @@ export class SpScatterRendererService extends SpBaseEchartsRenderer<CorrelationC
                 type: 'value',
                 min: 'dataMin',
                 max: 'dataMax',
+                name:
+                    widgetConfig.visualizationConfig.labelX ||
+                    `${xField.fullDbName} (${xField.measurementUnitResourceId ? xField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                nameLocation: 'center',
+                nameTextStyle: {
+                    fontSize: 20,
+                },
             },
             yAxis: {
                 type: 'value',
                 min: 'dataMin',
                 max: 'dataMax',
+                name:
+                    widgetConfig.visualizationConfig.labelY ||
+                    `${yField.fullDbName} (${yField.measurementUnitResourceId ? yField.measurementUnitResourceId.split('#').pop() : 'Unknown Unit'})`,
+                nameLocation: 'center',
+                nameTextStyle: {
+                    fontSize: 20,
+                },
             },
             series,
         });


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

<img width="650" height="732" alt="image" src="https://github.com/user-attachments/assets/feb15c79-a00b-472b-99f3-e83889152db1" />


### Purpose
This pr adds a option to add axis labels to 2d charts. By default, its the "fullDbName" and if set, the measurement unit.


PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
