### PR TITLE
fix: Modify swagger config to solve auth issue in Swagger interface

### DIFF
--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/OpenApiConfiguration.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/OpenApiConfiguration.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -42,8 +43,9 @@ public class OpenApiConfiguration {
     return new OpenAPI()
         .components(new Components()
             .addSecuritySchemes("bearerAuth",
-                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer"))
+                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT"))
             .parameters(makeAuthParams()))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
         .info(new Info()
             .title("Apache StreamPipes API")
             .description("This is the documentation of the Apache StreamPipes developer API.")


### PR DESCRIPTION
### Purpose
Enable JWT authentication support in the Swagger UI by adding the necessary OpenAPI configuration. Allows authorization requests using a Bearer token directly within the Swagger interface.


PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
