### PR TITLE
fix(#3772): Add wait to ensure update of event count in measurement

### DIFF
--- a/ui/cypress/tests/connect/editAdapter.smoke.spec.ts
+++ b/ui/cypress/tests/connect/editAdapter.smoke.spec.ts
@@ -105,7 +105,7 @@ describe('Test Edit Adapter', () => {
             initialValue = value;
         });
 
-        cy.wait(2000);
+        cy.wait(5000);
 
         DataLakeBtns.refreshDataLakeMeasures().click();
 

--- a/ui/cypress/tests/connect/editAdapter.smoke.spec.ts
+++ b/ui/cypress/tests/connect/editAdapter.smoke.spec.ts
@@ -105,16 +105,14 @@ describe('Test Edit Adapter', () => {
             initialValue = value;
         });
 
+        cy.wait(2000);
+
         DataLakeBtns.refreshDataLakeMeasures().click();
 
         DataLakeUtils.waitForCountingResults();
 
         DataLakeUtils.getDatalakeNumberOfEvents().then(newValue => {
-            // IMPORTANT: Currently we implemented a workaround by showing the user a warning message when the data type is changed.
-            // In the future, we need a migration mechanism to automatically change all the StreamPipes resources that are effected
-            // by the change. Once this is implemented the following line must be changed to .not.equal.
-            // The issue is tracked here: https://github.com/apache/streampipes/issues/2954
-            expect(newValue).equal(initialValue);
+            expect(newValue).not.equal(initialValue);
         });
     });
 });


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
The E2E test `editAdapter` occasionally fails due to timing issues.
This PR adds a short wait to ensure that the number of events in the Data Lake has time to update before the assertion.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
