### PR TITLE
Python 3.12 and 3.13 support

### DIFF
--- a/streampipes-client-python/pyproject.toml
+++ b/streampipes-client-python/pyproject.toml
@@ -53,10 +53,10 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9,<3.13"
 confluent-kafka = "~2, >=2.0.2"
 nats-py = "~2, >=2.2"
-pandas = ">=2.0, <3"
+pandas = ">=2.3, <3"
 pydantic = "~2, >=2.6.3"
 requests = "~2, >=2.28"
 typing-extensions = "~4, >=4.5"

--- a/streampipes-client-python/pyproject.toml
+++ b/streampipes-client-python/pyproject.toml
@@ -53,7 +53,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<3.14"
 confluent-kafka = "~2, >=2.0.2"
 nats-py = "~2, >=2.2"
 pandas = ">=2.3, <3"


### PR DESCRIPTION

### Purpose
#3778 for python 3.12 and 3.13. Small changes to pandas versioning and the python version in .toml. 


PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s):  no
