### PR TITLE
Speeding up compact adapter creation by replacing findAll with getting the specific adapter 

### DIFF
--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
@@ -18,6 +18,9 @@
 
 package org.apache.streampipes.connect.management.management;
 
+import java.util.List;
+import java.util.NoSuchElementException;
+
 import org.apache.streampipes.commons.exceptions.NoServiceEndpointsAvailableException;
 import org.apache.streampipes.commons.exceptions.SepaParseException;
 import org.apache.streampipes.commons.exceptions.connect.AdapterException;
@@ -36,14 +39,6 @@ import org.apache.streampipes.svcdiscovery.api.model.SpServiceUrlProvider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.FileWriter;
-import java.io.PrintWriter;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
 
 /**
  * This class is responsible for managing all the adapter instances which are
@@ -105,48 +100,9 @@ public class AdapterMasterManagement {
   }
 
   public AdapterDescription getAdapter(String elementId) throws AdapterException {
-
-    Map<String, Long> timings = new HashMap<>();
-
-    long t1 = System.nanoTime();
     AdapterDescription allAdapters = adapterInstanceStorage.getElementById(elementId);
-    timings.put("Overall", System.nanoTime() - t1);
-    saveTimingToCSV(timings);
     return allAdapters;
   }
-
-
-  private void saveTimingToCSV(Map<String, Long> timings) {
-    String filePath = "./logs/compact_adapter_timings.csv";
-    java.io.File file = new java.io.File(filePath);
-
-    // Create logs directory if it doesn't exist
-    file.getParentFile().mkdirs();
-
-    boolean fileExists = file.exists();
-
-    try (FileWriter fw = new FileWriter(file, true);
-         PrintWriter pw = new PrintWriter(fw)) {
-
-        // Write header only if file doesn't exist or is empty
-        if (!fileExists || file.length() == 0) {
-            pw.print("timestamp");
-            for (String key : timings.keySet()) {
-                pw.print("," + key);
-            }
-            pw.println();
-        }
-
-        pw.print(LocalDateTime.now());
-        for (Long timeNs : timings.values()) {
-            pw.print("," + timeNs / 1_000_000); // convert to milliseconds
-        }
-        pw.println();
-
-    } catch (Exception e) {
-        e.printStackTrace(); // Consider using proper logging instead
-    }
-}
 
   /**
    * First the adapter is stopped removed, then the corresponding data source is

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
@@ -41,7 +41,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 /**
- * This class is responsible for managing all the adapter instances which are executed on worker nodes
+ * This class is responsible for managing all the adapter instances which are
+ * executed on worker nodes
  */
 public class AdapterMasterManagement {
 
@@ -57,8 +58,7 @@ public class AdapterMasterManagement {
       IAdapterStorage adapterInstanceStorage,
       AdapterResourceManager adapterResourceManager,
       DataStreamResourceManager dataStreamResourceManager,
-      AdapterMetrics adapterMetrics
-  ) {
+      AdapterMetrics adapterMetrics) {
     this.adapterInstanceStorage = adapterInstanceStorage;
     this.adapterMetrics = adapterMetrics;
     this.adapterResourceManager = adapterResourceManager;
@@ -68,8 +68,7 @@ public class AdapterMasterManagement {
   public void addAdapter(
       AdapterDescription adapterDescription,
       String adapterId,
-      String principalSid
-  )
+      String principalSid)
       throws AdapterException {
 
     // Create elementId for datastream
@@ -92,8 +91,7 @@ public class AdapterMasterManagement {
       AdapterDescription adapterDescription,
       String adapterId,
       String streamId,
-      String principalSid
-  ) throws AdapterException {
+      String principalSid) throws AdapterException {
     var storedDescription = new SourcesManagement()
         .createAdapterDataStream(adapterDescription, streamId);
     storedDescription.setCorrespondingAdapterId(adapterId);
@@ -102,21 +100,13 @@ public class AdapterMasterManagement {
   }
 
   public AdapterDescription getAdapter(String elementId) throws AdapterException {
-    List<AdapterDescription> allAdapters = adapterInstanceStorage.findAll();
-
-    if (allAdapters != null && elementId != null) {
-      for (AdapterDescription ad : allAdapters) {
-        if (elementId.equals(ad.getElementId())) {
-          return ad;
-        }
-      }
-    }
-
-    throw new AdapterException("Could not find adapter with id: " + elementId);
+    AdapterDescription allAdapters = adapterInstanceStorage.getElementById(elementId);
+    return allAdapters;
   }
 
   /**
-   * First the adapter is stopped removed, then the corresponding data source is deleted
+   * First the adapter is stopped removed, then the corresponding data source is
+   * deleted
    *
    * @param elementId The elementId of the adapter instance
    * @throws AdapterException when adapter can not be stopped
@@ -146,7 +136,7 @@ public class AdapterMasterManagement {
   }
 
   public void stopStreamAdapter(String elementId,
-                                boolean forceStop) throws AdapterException {
+      boolean forceStop) throws AdapterException {
     AdapterDescription ad = adapterInstanceStorage.getElementById(elementId);
 
     try {
@@ -181,8 +171,7 @@ public class AdapterMasterManagement {
           ad.getAppId(),
           SpServiceUrlProvider.ADAPTER,
           ad.getDeploymentConfiguration()
-            .getDesiredServiceTags()
-      );
+              .getDesiredServiceTags());
 
       // Update selected endpoint URL of adapter
       ad.setSelectedEndpointUrl(baseUrl);
@@ -191,7 +180,8 @@ public class AdapterMasterManagement {
       // Invoke adapter instance
       WorkerRestClient.invokeStreamAdapter(baseUrl, elementId);
 
-      // register the adapter at the metrics manager so that the AdapterHealthCheck can send metrics
+      // register the adapter at the metrics manager so that the AdapterHealthCheck
+      // can send metrics
       adapterMetrics.register(ad.getElementId(), ad.getName());
 
       LOG.info("Started adapter " + elementId + " on: " + baseUrl);
@@ -202,8 +192,7 @@ public class AdapterMasterManagement {
 
   private void installDataSource(
       SpDataStream stream,
-      String principalSid
-  ) throws AdapterException {
+      String principalSid) throws AdapterException {
     try {
       new DataStreamVerifier(stream).verifyAndAdd(principalSid, false);
     } catch (SepaParseException e) {

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
@@ -37,7 +37,12 @@ import org.apache.streampipes.svcdiscovery.api.model.SpServiceUrlProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
@@ -100,9 +105,48 @@ public class AdapterMasterManagement {
   }
 
   public AdapterDescription getAdapter(String elementId) throws AdapterException {
+
+    Map<String, Long> timings = new HashMap<>();
+
+    long t1 = System.nanoTime();
     AdapterDescription allAdapters = adapterInstanceStorage.getElementById(elementId);
+    timings.put("Overall", System.nanoTime() - t1);
+    saveTimingToCSV(timings);
     return allAdapters;
   }
+
+
+  private void saveTimingToCSV(Map<String, Long> timings) {
+    String filePath = "./logs/compact_adapter_timings.csv";
+    java.io.File file = new java.io.File(filePath);
+
+    // Create logs directory if it doesn't exist
+    file.getParentFile().mkdirs();
+
+    boolean fileExists = file.exists();
+
+    try (FileWriter fw = new FileWriter(file, true);
+         PrintWriter pw = new PrintWriter(fw)) {
+
+        // Write header only if file doesn't exist or is empty
+        if (!fileExists || file.length() == 0) {
+            pw.print("timestamp");
+            for (String key : timings.keySet()) {
+                pw.print("," + key);
+            }
+            pw.println();
+        }
+
+        pw.print(LocalDateTime.now());
+        for (Long timeNs : timings.values()) {
+            pw.print("," + timeNs / 1_000_000); // convert to milliseconds
+        }
+        pw.println();
+
+    } catch (Exception e) {
+        e.printStackTrace(); // Consider using proper logging instead
+    }
+}
 
   /**
    * First the adapter is stopped removed, then the corresponding data source is

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
@@ -17,10 +17,6 @@
  */
 
 package org.apache.streampipes.connect.management.management;
-
-import java.util.List;
-import java.util.NoSuchElementException;
-
 import org.apache.streampipes.commons.exceptions.NoServiceEndpointsAvailableException;
 import org.apache.streampipes.commons.exceptions.SepaParseException;
 import org.apache.streampipes.commons.exceptions.connect.AdapterException;
@@ -39,6 +35,9 @@ import org.apache.streampipes.svcdiscovery.api.model.SpServiceUrlProvider;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * This class is responsible for managing all the adapter instances which are
@@ -100,8 +99,11 @@ public class AdapterMasterManagement {
   }
 
   public AdapterDescription getAdapter(String elementId) throws AdapterException {
-    AdapterDescription allAdapters = adapterInstanceStorage.getElementById(elementId);
-    return allAdapters;
+    AdapterDescription adapter = adapterInstanceStorage.getElementById(elementId);
+    if (adapter == null) {
+        throw new AdapterException("Adapter with ID " + elementId + " not found");
+    }
+    return adapter;
   }
 
   /**


### PR DESCRIPTION
### Purpose
Speeding up the adapter creation via the compact adapter endpoint
### Remarks
Replaced .findAll with getAdapter(elementId)

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
