### PR TITLE
Migration for missing Export Provider Type "FOLDER"

### DIFF
--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/AvailableMigrations.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/AvailableMigrations.java
@@ -27,6 +27,7 @@ import org.apache.streampipes.service.core.migrations.v093.AdapterMigration;
 import org.apache.streampipes.service.core.migrations.v093.StoreEmailTemplatesMigration;
 import org.apache.streampipes.service.core.migrations.v095.MergeFilenamesAndRenameDuplicatesMigration;
 import org.apache.streampipes.service.core.migrations.v0980.AddDataLakeMeasureViewMigration;
+import org.apache.streampipes.service.core.migrations.v0980.AddDefaultExportProviderMigration;
 import org.apache.streampipes.service.core.migrations.v0980.ModifyAssetLinkTypesMigration;
 import org.apache.streampipes.service.core.migrations.v0980.ModifyAssetLinksMigration;
 import org.apache.streampipes.service.core.migrations.v970.AddDataLakePipelineTemplateMigration;
@@ -58,7 +59,8 @@ public class AvailableMigrations {
         new AddDataLakePipelineTemplateMigration(),
         new ModifyAssetLinksMigration(),
         new ModifyAssetLinkTypesMigration(),
-        new AddDataLakeMeasureViewMigration()
+        new AddDataLakeMeasureViewMigration(),
+        new AddDefaultExportProviderMigration()
     );
   }
 }

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/AddDefaultExportProviderMigration.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/AddDefaultExportProviderMigration.java
@@ -35,7 +35,7 @@ public class AddDefaultExportProviderMigration implements Migration {
 
     try {
 
-      boolean shouldExecute = storage.getAll().get(0).getExportProviderSettings() == null  || storage.getAll().get(0).getExportProviderSettings().isEmpty();
+      boolean shouldExecute = storage.get().getExportProviderSettings() == null  || storage.get().getExportProviderSettings().isEmpty();
 
       return shouldExecute;
     } catch (Exception e) {
@@ -47,7 +47,7 @@ public class AddDefaultExportProviderMigration implements Migration {
   @Override
   public void executeMigration() throws IOException {
 
-    var coreCfg = storage.getAll().get(0);
+    var coreCfg = storage.get();
 
     coreCfg.setExportProviderSettings(new DefaultExportProviderConfig().make());
 

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/AddDefaultExportProviderMigration.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/AddDefaultExportProviderMigration.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.service.core.migrations.v0980;
+
+import org.apache.streampipes.model.configuration.DefaultExportProviderConfig;
+import org.apache.streampipes.service.core.migrations.Migration;
+import org.apache.streampipes.storage.api.ISpCoreConfigurationStorage;
+import org.apache.streampipes.storage.management.StorageDispatcher;
+
+import java.io.IOException;
+
+public class AddDefaultExportProviderMigration implements Migration {
+
+  private final ISpCoreConfigurationStorage storage = StorageDispatcher.INSTANCE.getNoSqlStore()
+      .getSpCoreConfigurationStorage();
+
+  @Override
+  public boolean shouldExecute() {
+
+    try {
+
+      boolean shouldExecute = storage.getAll().get(0).getExportProviderSettings() == null  || storage.getAll().get(0).getExportProviderSettings().isEmpty();
+
+      return shouldExecute;
+    } catch (Exception e) {
+      return true;
+    }
+
+  }
+
+  @Override
+  public void executeMigration() throws IOException {
+
+    var coreCfg = storage.getAll().get(0);
+
+    coreCfg.setExportProviderSettings(new DefaultExportProviderConfig().make());
+
+    storage.updateElement(coreCfg);
+
+  }
+
+  @Override
+  public String getDescription() {
+    return "Migrating SPCoreConfiguration to include the default folder.";
+  }
+}


### PR DESCRIPTION

### Purpose
Migration for providing FOLDER as default export provider if a database already exists. 
Works also if for some reason FOLDER is deleted accidentally.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
