### PR TITLE
Small fix for the failing test in PipelineAsset.

### DIFF
--- a/ui/cypress/tests/pipeline/pipelineAsset.spec.ts
+++ b/ui/cypress/tests/pipeline/pipelineAsset.spec.ts
@@ -55,7 +55,7 @@ describe('Test Saving Pipeline with Asset Link', () => {
     });
 
     it('Add Pipeline to Asset during creation', () => {
-        PipelineUtils.deletePipeline(`Pipeline Test`);
+        PipelineUtils.editPipeline('Pipeline Test');
 
         // Go Back to Asset
         AssetUtils.goToAssets();


### PR DESCRIPTION
### Purpose

To get to Pipeline Overview  (close the slide in Popup) call Edit instead of delete to prevent the side effect of the pipeline asset link being deleted. 

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
