### PR TITLE
fix(3887): permission objects lost after exporting and re importing assets with sanitized resource ids

### DIFF
--- a/streampipes-data-export/src/main/java/org/apache/streampipes/export/dataimport/PerformImportGenerator.java
+++ b/streampipes-data-export/src/main/java/org/apache/streampipes/export/dataimport/PerformImportGenerator.java
@@ -30,7 +30,6 @@ import org.apache.streampipes.export.resolver.MeasurementResolver;
 import org.apache.streampipes.export.resolver.PipelineResolver;
 import org.apache.streampipes.manager.file.FileHandler;
 import org.apache.streampipes.model.SpDataStream;
-import org.apache.streampipes.model.connect.adapter.AdapterDescription;
 import org.apache.streampipes.model.dashboard.DashboardModel;
 import org.apache.streampipes.model.datalake.DataExplorerWidgetModel;
 import org.apache.streampipes.model.datalake.DataLakeMeasure;
@@ -81,7 +80,7 @@ public class PerformImportGenerator extends ImportGenerator<Void> {
   protected void handleAdapter(String document, String adapterId) throws JsonProcessingException {
     if (shouldStore(adapterId, config.getAdapters())) {
       writeDocument(document, new AdapterResolver());
-      permissionsToStore.add(new PermissionInfo(adapterId, AdapterDescription.class));
+      // adapters do not have permissions associated
     }
   }
 
@@ -89,7 +88,8 @@ public class PerformImportGenerator extends ImportGenerator<Void> {
   protected void handleChart(String document, String chartId) throws JsonProcessingException {
     if (shouldStore(chartId, config.getDataViews())) {
       writeDocument(document, new ChartResolver());
-      permissionsToStore.add(new PermissionInfo(chartId, DataExplorerWidgetModel.class));
+      var chart = new ChartResolver().deserializeDocument(document);
+      permissionsToStore.add(new PermissionInfo(chart.getElementId(), DataExplorerWidgetModel.class));
     }
   }
 
@@ -97,7 +97,8 @@ public class PerformImportGenerator extends ImportGenerator<Void> {
   protected void handleDashboard(String document, String dashboardId) throws JsonProcessingException {
     if (shouldStore(dashboardId, config.getDashboards())) {
       writeDocument(document, new DashboardResolver());
-      permissionsToStore.add(new PermissionInfo(dashboardId, DashboardModel.class));
+      var dashboard = new DashboardResolver().deserializeDocument(document);
+      permissionsToStore.add(new PermissionInfo(dashboard.getElementId(), DashboardModel.class));
     }
   }
 
@@ -105,7 +106,8 @@ public class PerformImportGenerator extends ImportGenerator<Void> {
   protected void handleDataSource(String document, String dataSourceId) throws JsonProcessingException {
     if (shouldStore(dataSourceId, config.getDataSources())) {
       writeDocument(document, new DataSourceResolver());
-      permissionsToStore.add(new PermissionInfo(dataSourceId, SpDataStream.class));
+      var dataStream = new DataSourceResolver().deserializeDocument(document);
+      permissionsToStore.add(new PermissionInfo(dataStream.getElementId(), SpDataStream.class));
     }
   }
 

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/AvailableMigrations.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/AvailableMigrations.java
@@ -28,6 +28,7 @@ import org.apache.streampipes.service.core.migrations.v093.StoreEmailTemplatesMi
 import org.apache.streampipes.service.core.migrations.v095.MergeFilenamesAndRenameDuplicatesMigration;
 import org.apache.streampipes.service.core.migrations.v0980.AddDataLakeMeasureViewMigration;
 import org.apache.streampipes.service.core.migrations.v0980.AddDefaultExportProviderMigration;
+import org.apache.streampipes.service.core.migrations.v0980.FixImportedPermissionsMigration;
 import org.apache.streampipes.service.core.migrations.v0980.ModifyAssetLinkTypesMigration;
 import org.apache.streampipes.service.core.migrations.v0980.ModifyAssetLinksMigration;
 import org.apache.streampipes.service.core.migrations.v970.AddDataLakePipelineTemplateMigration;
@@ -60,7 +61,8 @@ public class AvailableMigrations {
         new ModifyAssetLinksMigration(),
         new ModifyAssetLinkTypesMigration(),
         new AddDataLakeMeasureViewMigration(),
-        new AddDefaultExportProviderMigration()
+        new AddDefaultExportProviderMigration(),
+        new FixImportedPermissionsMigration()
     );
   }
 }

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/FixImportedPermissionsMigration.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/FixImportedPermissionsMigration.java
@@ -54,33 +54,33 @@ public class FixImportedPermissionsMigration implements Migration {
   }
 
   private void migrateDashboardPermissions() {
-    LOG.info("Strart migrate permissions for dashboards");
+    LOG.debug("Start migrate permissions for dashboards");
     var dataExplorerDashboardStorage = StorageDispatcher.INSTANCE
         .getNoSqlStore()
         .getDataExplorerDashboardStorage();
     var dashboards = dataExplorerDashboardStorage.findAll();
     migrateResourcePermissions(dashboards);
-    LOG.info("Finished migrate permissions for dashboards");
+    LOG.debug("Finished migrate permissions for dashboards");
   }
 
   private void migrateChartsPermissions() {
-    LOG.info("Strart migrate permissions for charts");
+    LOG.debug("Start migrate permissions for charts");
     var dataExplorerWidgetStorage = StorageDispatcher.INSTANCE
         .getNoSqlStore()
         .getDataExplorerWidgetStorage();
     var charts = dataExplorerWidgetStorage.findAll();
     migrateResourcePermissions(charts);
-    LOG.info("Finished migrate permissions for charts");
+    LOG.debug("Finished migrate permissions for charts");
   }
 
   private void migrateDataStreamPermissions() {
-    LOG.info("Strart migrate permissions for data streams");
+    LOG.debug("Start migrate permissions for data streams");
     var dataStreamStorage =
         StorageDispatcher.INSTANCE.getNoSqlStore()
                                   .getDataStreamStorage();
     var dataStreams = dataStreamStorage.findAll();
     migrateResourcePermissions(dataStreams);
-    LOG.info("Finished migrate permissions for data streams");
+    LOG.debug("Finished migrate permissions for data streams");
   }
 
   /**

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/FixImportedPermissionsMigration.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v0980/FixImportedPermissionsMigration.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.service.core.migrations.v0980;
+
+import org.apache.streampipes.model.shared.api.Storable;
+import org.apache.streampipes.service.core.migrations.Migration;
+import org.apache.streampipes.storage.api.IPermissionStorage;
+import org.apache.streampipes.storage.management.StorageDispatcher;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This migration is required because the export/import process sanitizes resource ids for the permissions.
+ * This breaks the link between resources and their permissions after import.
+ */
+public class FixImportedPermissionsMigration implements Migration {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixImportedPermissionsMigration.class);
+
+  private final IPermissionStorage permissionStorage =
+      StorageDispatcher.INSTANCE.getNoSqlStore()
+                                .getPermissionStorage();
+
+  @Override
+  public boolean shouldExecute() {
+    return true;
+  }
+
+  @Override
+  public void executeMigration() throws IOException {
+    migrateDashboardPermissions();
+    migrateChartsPermissions();
+    migrateDataStreamPermissions();
+  }
+
+  private void migrateDashboardPermissions() {
+    LOG.info("Strart migrate permissions for dashboards");
+    var dataExplorerDashboardStorage = StorageDispatcher.INSTANCE
+        .getNoSqlStore()
+        .getDataExplorerDashboardStorage();
+    var dashboards = dataExplorerDashboardStorage.findAll();
+    migrateResourcePermissions(dashboards);
+    LOG.info("Finished migrate permissions for dashboards");
+  }
+
+  private void migrateChartsPermissions() {
+    LOG.info("Strart migrate permissions for charts");
+    var dataExplorerWidgetStorage = StorageDispatcher.INSTANCE
+        .getNoSqlStore()
+        .getDataExplorerWidgetStorage();
+    var charts = dataExplorerWidgetStorage.findAll();
+    migrateResourcePermissions(charts);
+    LOG.info("Finished migrate permissions for charts");
+  }
+
+  private void migrateDataStreamPermissions() {
+    LOG.info("Strart migrate permissions for data streams");
+    var dataStreamStorage =
+        StorageDispatcher.INSTANCE.getNoSqlStore()
+                                  .getDataStreamStorage();
+    var dataStreams = dataStreamStorage.findAll();
+    migrateResourcePermissions(dataStreams);
+    LOG.info("Finished migrate permissions for data streams");
+  }
+
+  /**
+   * Migrate permissions for the given resources, by replacing the sanitized id with the original id.
+   */
+  private void migrateResourcePermissions(List<? extends Storable> resources) {
+    resources.forEach(resource -> {
+      // This uses the same sanitization logic as the exporter
+      var sanitizedId = sanitize(resource.getElementId());
+      var permissions = permissionStorage.getUserPermissionsForObject(sanitizedId);
+
+      permissions.forEach(permission -> {
+        permission.setObjectInstanceId(resource.getElementId());
+        permissionStorage.updateElement(permission);
+        LOG.info(
+            "Updated permission id from {} to {}",
+            sanitizedId,
+            resource.getElementId()
+        );
+      });
+    });
+  }
+
+  @Override
+  public String getDescription() {
+    return "Fix permissions of imported data streams, dashboards and charts";
+  }
+
+  private String sanitize(String resourceId) {
+    return resourceId.replaceAll(":", "")
+                     .replaceAll("\\.", "");
+  }
+}


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
This PR addresses the loss of permission objects when importing assets with sanitized resource IDs.

The fix includes two parts:

1. A migration script that restores missing permission objects in already affected installations.
2. An update to the import logic to ensure the original resource ID is used in permission objects, preventing future mismatches.



### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
