### PR TITLE
Migrate DataStream Name in existing Pipelines when updating an Adapter

### DIFF
--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterUpdateManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterUpdateManagement.java
@@ -60,7 +60,7 @@ public class AdapterUpdateManagement {
 
   public void updateAdapter(AdapterDescription ad)
       throws AdapterException {
-    // update adapter in database
+    // update adapter in database 
     this.adapterResourceManager.encryptAndUpdate(ad);
     boolean shouldRestart = ad.isRunning();
 
@@ -187,6 +187,7 @@ public class AdapterUpdateManagement {
         .peek(s -> {
           if (s.getElementId().equals(updatedAdapter.getCorrespondingDataStreamElementId())) {
             s.setEventSchema(updatedAdapter.getEventSchema());
+            s.setName(updatedAdapter.getName());
           }
         })
         .toList();


### PR DESCRIPTION
### Purpose

Migrate the DataStream Name in existing pipelines when changing the adapter name. New name only needs to be migrated into existing pipelines. 

### Remarks

Name in document data stream is already changed, 

PR introduces (a) breaking change(s): no 

PR introduces (a) deprecation(s): no
