### PR TITLE
Fix for missing pre-used labels in label selection 

### DIFF
--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-labels/asset-details-labels.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-labels/asset-details-labels.component.ts
@@ -104,6 +104,7 @@ export class AssetDetailsLabelsComponent implements OnInit, OnChanges {
     ngOnChanges(changes: SimpleChanges) {
         if (changes['asset']) {
             this.refreshCurrentLabels();
+            this.updateFilteredLabels();
         }
     }
 


### PR DESCRIPTION

Fix for missing pre-used labels in label selection.
 
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
