### PR TITLE
fix: Fixing Non-deterministic Behavior in StreamPipesApiPathTest

### DIFF
--- a/streampipes-client/src/test/java/org/apache/streampipes/client/util/StreamPipesApiPathTest.java
+++ b/streampipes-client/src/test/java/org/apache/streampipes/client/util/StreamPipesApiPathTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class StreamPipesApiPathTest {
   Map<String, String> queryParameters = new HashMap();
@@ -62,7 +63,12 @@ public class StreamPipesApiPathTest {
         .withQueryParameters(queryParameters)
         .toString();
 
-    Assertions.assertEquals(baseRoute + "?two=v2&one=v1", result);
+    String queryString = result.substring(result.indexOf("?") + 1);
+    Set<String> actual = Set.of(queryString.split("&"));
+
+    Set<String> expected = Set.of("one=v1", "two=v2");
+
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
Fixes a non-deterministic test in `StreamPipesApiPathTest.testWithMultipleQueryParameters`.

The test assumed a specific ordering of query parameters when building a URL string. Since the underlying `queryParameters` map is a `HashMap`, it does not guarantee iteration order.  
As a result, two valid outputs were possible:

- `?one=v1&two=v2`  
- `?two=v2&one=v1`  

The test compared the full URL as a raw string, causing nondeterministic failures during repeated runs or under NonDex.

### **Reproduce Test**  
The non-deterministic behavior can be reliably reproduced with NonDex using:

```bash
mvn edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -Dtest=org.apache.streampipes.client.util.StreamPipesApiPathTest#testWithMultipleQueryParameters
```
This will intermittently produce failures depending on the map iteration order.

### **The Fix**  

Instead of asserting the entire query string in a fixed order, the test now extracts the query portion and splits it into key-value pairs, then compares parameter sets ignoring order.

This ensures the test validates logical correctness rather than accidental ordering, eliminating nondeterministic behavior while still verifying correctness of query generation.

---

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
