### PR TITLE
fix: Fix CsvParserTest caused by JSON field order

### DIFF
--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParserTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParserTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,7 +64,11 @@ public class CsvParserTest extends ParserTest {
 
     var result = parser.getGuessSchema(event);
 
-    assertEquals(sampleExpected, result);
+    assertEquals(sampleExpected.getEventSchema(), result.getEventSchema());
+    assertEquals(sampleExpected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    String preview = result.getEventPreview().get(0).toString();
+    assertTrue(preview.equals("{\"k2\":2.0,\"k1\":\"v1\"}") || preview.equals("{\"k1\":\"v1\",\"k2\":2.0}"));
   }
 
   @Test
@@ -74,7 +79,11 @@ public class CsvParserTest extends ParserTest {
 
     var result = parser.getGuessSchema(event);
 
-    assertEquals(sampleExpected, result);
+    assertEquals(sampleExpected.getEventSchema(), result.getEventSchema());
+    assertEquals(sampleExpected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    String preview = result.getEventPreview().get(0).toString();
+    assertTrue(preview.equals("{\"k2\":2.0,\"k1\":\"v1\"}") || preview.equals("{\"k1\":\"v1\",\"k2\":2.0}"));
   }
 
   @Test


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
This pull request makes the ```CsvParserTest.getGuessSchemaWithHeaderAndComma``` and ```CsvParserTest.getGuessSchemaWithHeaderAndSemicolon``` tests deterministic by removing their reliance on a fixed JSON key ordering in the event preview. Previously, these tests assumed a specific ordering of ```k1``` and ```k2``` in the serialized preview string, which can vary across JVMs and under tools like [NonDex](https://github.com/TestingResearchIllinois/NonDex) that shuffle iteration order. 

### Reproduce Failure
To reproduce the failures, run NonDex on ```streampipes-extensions-management``` module using the following command:
```
mvn -pl streampipes-extensions-management edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.streampipes.extensions.management.connect.adapter.parser.CsvParserTest#<testMethod>
```
Replace ```<testMethod>``` with one of:
```
getGuessSchemaWithHeaderAndComma
getGuessSchemaWithHeaderAndSemicolon
```

### The Fix
The test is updated to still construct a ```CsvParser``` with a header row (using ```,``` and ```;``` as delimiters respectively), feed in the same sample input, and assert that ```eventSchema``` and ```fieldStatusInfo``` match ```sampleExpected```. The change is in the preview assertion, where instead of checking equality against a single hard-coded string, the tests now treat both ```{"k2":2.0,"k1":"v1"}``` and ```{"k1\":\"v1\",\"k2\":2.0}``` as valid outputs, making the test deterministic.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
