### PR TITLE
fix: Fixing Non-deterministic Tests caused by HashMap

### DIFF
--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/GeoJsonParserTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/GeoJsonParserTest.java
@@ -56,7 +56,7 @@ public class GeoJsonParserTest {
   );
 
   @Test
-  public void getGuessSchema() {
+  public void getGuessSchema() throws Exception {
     var expected = GuessSchemaBuilder.create()
         .property(PrimitivePropertyBuilder
             .create(Datatypes.Float, "longitude")
@@ -82,7 +82,18 @@ public class GeoJsonParserTest {
 
     var result = parser.getGuessSchema(toEvent(event));
 
-    Assertions.assertEquals(expected, result);
+    Assertions.assertEquals(expected.getEventSchema(), result.getEventSchema());
+    Assertions.assertEquals(expected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    Map<String, Object> expectedMap =
+            mapper.readValue(expected.getEventPreview().get(0), Map.class);
+
+    Map<String, Object> actualMap =
+            mapper.readValue(result.getEventPreview().get(0), Map.class);
+
+    Assertions.assertEquals(expectedMap, actualMap);
   }
 
   @Test

--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonArrayKeyParserTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonArrayKeyParserTest.java
@@ -26,6 +26,7 @@ import org.apache.streampipes.sdk.builder.PrimitivePropertyBuilder;
 import org.apache.streampipes.sdk.builder.adapter.GuessSchemaBuilder;
 import org.apache.streampipes.sdk.utils.Datatypes;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -46,7 +47,7 @@ public class JsonArrayKeyParserTest extends ParserTest {
   InputStream event = toStream("{\"arr\":[{\"k1\": \"v1\", \"k2\": 2},{\"k1\": \"v2\", \"k2\": 3}]}");
 
   @Test
-  public void getGuessSchema() {
+  public void getGuessSchema() throws Exception {
     var expected = GuessSchemaBuilder.create()
         .property(PrimitivePropertyBuilder
             .create(Datatypes.String, K1)
@@ -64,7 +65,18 @@ public class JsonArrayKeyParserTest extends ParserTest {
 
     var result = parser.getGuessSchema(event);
 
-    assertEquals(expected, result);
+    assertEquals(expected.getEventSchema(), result.getEventSchema());
+    assertEquals(expected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    Map<String, Object> expectedMap =
+            mapper.readValue(expected.getEventPreview().get(0), Map.class);
+
+    Map<String, Object> actualMap =
+            mapper.readValue(result.getEventPreview().get(0), Map.class);
+
+    assertEquals(expectedMap, actualMap);
   }
 
   @Test

--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonArrayParserTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonArrayParserTest.java
@@ -26,6 +26,7 @@ import org.apache.streampipes.sdk.builder.PrimitivePropertyBuilder;
 import org.apache.streampipes.sdk.builder.adapter.GuessSchemaBuilder;
 import org.apache.streampipes.sdk.utils.Datatypes;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -46,7 +47,7 @@ public class JsonArrayParserTest extends ParserTest {
   InputStream event = toStream("[{\"k1\": \"v1\", \"k2\": 2},{\"k1\": \"v2\", \"k2\": 3}]");
 
   @Test
-  public void getGuessSchema() {
+  public void getGuessSchema() throws Exception {
 
     var expected = GuessSchemaBuilder.create()
         .property(PrimitivePropertyBuilder
@@ -65,7 +66,18 @@ public class JsonArrayParserTest extends ParserTest {
 
     var result = parser.getGuessSchema(event);
 
-    assertEquals(expected, result);
+    assertEquals(expected.getEventSchema(), result.getEventSchema());
+    assertEquals(expected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    Map<String, Object> expectedMap =
+            mapper.readValue(expected.getEventPreview().get(0), Map.class);
+
+    Map<String, Object> actualMap =
+            mapper.readValue(result.getEventPreview().get(0), Map.class);
+
+    assertEquals(expectedMap, actualMap);
   }
 
   @Test

--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonObjectParsersTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/json/JsonObjectParsersTest.java
@@ -26,6 +26,7 @@ import org.apache.streampipes.sdk.builder.PrimitivePropertyBuilder;
 import org.apache.streampipes.sdk.builder.adapter.GuessSchemaBuilder;
 import org.apache.streampipes.sdk.utils.Datatypes;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
@@ -45,7 +46,7 @@ public class JsonObjectParsersTest extends ParserTest {
 
 
   @Test
-  public void getGuessSchema() {
+  public void getGuessSchema() throws Exception {
     var expected = GuessSchemaBuilder.create()
         .property(PrimitivePropertyBuilder
             .create(Datatypes.String, K1)
@@ -63,7 +64,18 @@ public class JsonObjectParsersTest extends ParserTest {
 
     var result = parser.getGuessSchema(event);
 
-    assertEquals(expected, result);
+    assertEquals(expected.getEventSchema(), result.getEventSchema());
+    assertEquals(expected.getFieldStatusInfo(), result.getFieldStatusInfo());
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    Map<String, Object> expectedMap =
+            mapper.readValue(expected.getEventPreview().get(0), Map.class);
+
+    Map<String, Object> actualMap =
+            mapper.readValue(result.getEventPreview().get(0), Map.class);
+
+    assertEquals(expectedMap, actualMap);
   }
 
 


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### What is the purpose of the change

Fixes nondeterministic tests in  
`org.apache.streampipes.extensions.management.connect.adapter.parser.json`
```
.GeoJsonParserTest#getGuessSchema
.JsonArrayKeyParserTest#getGuessSchema
.JsonArrayParserTest#getGuessSchema
.JsonObjectParsersTest#getGuessSchema
```

The test previously performed a full `assertEquals(expected, result)` on the entire `GuessSchema` object.  
However, `GuessSchemaBuilder` stores event samples in a `HashMap`:

`this.samples = new HashMap<>();`

Since HashMap does not guarantee key iteration order, the JSON generated in eventPreview may serialize fields in different orders, such as:

`{"longitude": 6.94, "latitude": 51.43, "temperature": 5.0}` **or** `{"latitude": 51.43, "temperature": 5.0, "longitude": 6.94}`


These variations are semantically identical but cause strict equality checks to fail, causing nondeterministic failures during repeated runs or under NonDex.

### Reproduce Test
The non-deterministic behavior can be reliably reproduced with NonDex using:

```bash
mvn edu.illinois:nondex-maven-plugin:2.2.1:nondex \
  -Dtest=org.apache.streampipes.extensions.management.connect.adapter.parser.json.GeoJsonParserTest#getGuessSchema
```
The same issue also appears in:
```
.JsonArrayKeyParserTest#getGuessSchema
.JsonArrayParserTest#getGuessSchema
.JsonObjectParsersTest#getGuessSchema
```
This will intermittently produce failures depending on the map iteration order.


### The Fix

Instead of asserting equality on the entire GuessSchema object, it now parses the JSON preview entries into Map<String, Object> then check equivalency using 

`assertEquals(expectedMap, actualMap);`

This performs structural JSON comparison, ensuring correctness while ignoring nondeterministic key ordering.

---
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
