### PR TITLE
Enable `retryOnStatusCodeFailure` when calling `resetStreamPipes`

### DIFF
--- a/ui/cypress/support/general/resetStreamPipes.ts
+++ b/ui/cypress/support/general/resetStreamPipes.ts
@@ -31,5 +31,6 @@ export const resetStreamPipes = () => {
         auth: {
             bearer: window.localStorage.getItem('auth-token'),
         },
+        retryOnStatusCodeFailure: true,
     });
 };


### PR DESCRIPTION
### Purpose

I was looking at Develocity and noticed there's [a test that seems to be quite prone to flakiness](https://develocity.apache.org/scans/tests?search.buildToolType=npm&search.rootProjectNames=apache-streampipes&search.startTimeMax=1765580399999&search.startTimeMin=1764889200000&search.tasks=cypress&search.timeZoneId=Europe%2FZurich&tests.container=cypress%2Ftests%2Fconnect%2FenhancedAdapterDeletion.smoke.spec.ts&tests.test=Test%20Enhanced%20Adapter%20Deletion%20%C2%BB%20Test%20Admin%20Should%20Be%20Able%20to%20Delete%20Adapter%20and%20Not%20Owned%20Associated%20Pipelines). I was indeed able to reproduce the issue locally ([the reset endpoint returns a 500](https://develocity.apache.org/s/hfqwooeg6e66c/tests/process/apache-streampipes@cypress/details/cypress%2Ftests%2Fconnect%2FenhancedAdapterDeletion.smoke.spec.ts/Test%20Enhanced%20Adapter%20Deletion%20%C2%BB%20Test%20Admin%20Should%20Be%20Able%20to%20Delete%20Adapter%20and%20Not%20Owned%20Associated%20Pipelines?focused-exception-line=0-0&top-execution=1)) and noticed that a simple `retryOnStatusCodeFailure` seems to help reduce the flakiness. Hope this helps! 🙂 

---

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
