### PR TITLE
fix(#3974): reload asset filter after adding asset or asset link

### DIFF
--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
@@ -87,6 +87,14 @@ export class SpAssetBrowserService {
             this.reloadFilters();
         });
     }
+    /**
+     * Reloads asset data from the backend.
+     * This method should be called after creating, updating, or deleting assets or asset links
+     * to ensure the filter reflects the latest data.
+     */
+    reloadAssetData(): void {
+        this.loadAssetData();
+    }
 
     private reloadFilters(): void {
         if (

--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
@@ -87,14 +87,6 @@ export class SpAssetBrowserService {
             this.reloadFilters();
         });
     }
-    /**
-     * Reloads asset data from the backend.
-     * This method should be called after creating, updating, or deleting assets or asset links
-     * to ensure the filter reflects the latest data.
-     */
-    reloadAssetData(): void {
-        this.loadAssetData();
-    }
 
     private reloadFilters(): void {
         if (

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
@@ -33,7 +33,11 @@ import {
     SpAssetModel,
 } from '@streampipes/platform-services';
 import { SpManageAssetLinksDialogComponent } from '../../../../../dialog/manage-asset-links/manage-asset-links-dialog.component';
-import { DialogService, PanelType } from '@streampipes/shared-ui';
+import {
+    DialogService,
+    PanelType,
+    SpAssetBrowserService,
+} from '@streampipes/shared-ui';
 import { EditAssetLinkDialogComponent } from '../../../../../dialog/edit-asset-link/edit-asset-link-dialog.component';
 import { TranslateService } from '@ngx-translate/core';
 import { AssetLinkTableComponent } from '../../../view-asset/view-asset-links/asset-link-table/asset-link-table.component';
@@ -66,6 +70,7 @@ export class AssetDetailsLinksComponent implements OnInit {
         private genericStorageService: GenericStorageService,
         private dialogService: DialogService,
         private translateService: TranslateService,
+        private assetBrowserService: SpAssetBrowserService,
     ) {}
 
     ngOnInit(): void {
@@ -97,6 +102,7 @@ export class AssetDetailsLinksComponent implements OnInit {
             if (assetLinks) {
                 this.asset.assetLinks = assetLinks;
                 this.assetLinkTable?.refreshData();
+                this.assetBrowserService.reloadAssetData();
             }
         });
     }
@@ -129,6 +135,7 @@ export class AssetDetailsLinksComponent implements OnInit {
                 this.asset.assetLinks.push(storedLink);
                 this.asset.assetLinks = [...this.asset.assetLinks];
                 this.assetLinkTable?.refreshData();
+                this.assetBrowserService.reloadAssetData();
             }
         });
     }

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
@@ -102,7 +102,7 @@ export class AssetDetailsLinksComponent implements OnInit {
             if (assetLinks) {
                 this.asset.assetLinks = assetLinks;
                 this.assetLinkTable?.refreshData();
-                this.assetBrowserService.reloadAssetData();
+                this.assetBrowserService.loadAssetData();
             }
         });
     }
@@ -135,7 +135,7 @@ export class AssetDetailsLinksComponent implements OnInit {
                 this.asset.assetLinks.push(storedLink);
                 this.asset.assetLinks = [...this.asset.assetLinks];
                 this.assetLinkTable?.refreshData();
-                this.assetBrowserService.reloadAssetData();
+                this.assetBrowserService.loadAssetData();
             }
         });
     }

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
@@ -164,7 +164,7 @@ export class SpAssetOverviewComponent implements OnInit {
         dialogRef.afterClosed().subscribe(ev => {
             if (ev) {
                 this.loadAssets();
-                this.assetBrowserService.reloadAssetData();
+                this.assetBrowserService.loadAssetData();
                 this.goToDetailsView(assetModel, true);
             }
         });

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
@@ -163,6 +163,8 @@ export class SpAssetOverviewComponent implements OnInit {
 
         dialogRef.afterClosed().subscribe(ev => {
             if (ev) {
+                this.loadAssets();
+                this.assetBrowserService.reloadAssetData();
                 this.goToDetailsView(assetModel, true);
             }
         });


### PR DESCRIPTION
### Purpose

This PR fixes an issue where the asset filter was not refreshed after creating new assets or asset links.

Previously, the asset filter data was only loaded on initialization. As a result, newly created assets or asset links were not reflected in the filter until the page was manually refreshed.

This change ensures that the asset browser data is reloaded immediately after:
- Creating a new asset
- Creating or managing asset links

As a result, the filter always reflects the latest asset state without requiring a full page reload.

### Changes

- Added a public `reloadAssetData()` method to `SpAssetBrowserService`
- Triggered asset browser reload after asset creation in the asset overview component
- Triggered asset browser reload after creating or managing asset links in the asset details links component

### How to test

1. Open the Assets page
2. Create a new asset → the asset filter updates immediately
3. Add or manage asset links for an existing asset → the asset filter updates without refreshing the page

### Remarks

This change is limited to the UI layer and does not affect backend APIs or data models.
The reload behavior is consistent with existing reload logic already used after asset deletion or saving.

PR introduces breaking changes: **no**

PR introduces deprecations: **no**
