### PR TITLE
[#2178] Refactor CouchDB Utils into focused utility classes

### DIFF
--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+import org.apache.streampipes.commons.environment.Environment;
+
+import org.apache.commons.codec.binary.Base64;
+
+
+public class CouchDbAuthUtils {
+
+  private final Environment environment;
+
+  public CouchDbAuthUtils(Environment environment) {
+    this.environment = environment;
+  }
+
+  public String getBasicAuthHeaderValue() {
+    String auth = environment.getCouchDbUsername().getValueOrDefault()
+        + ":" + environment.getCouchDbPassword().getValueOrDefault();
+    return new String(Base64.encodeBase64(auth.getBytes()));
+  }
+}
+

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
@@ -22,7 +22,7 @@ import org.apache.streampipes.commons.environment.Environment;
 import org.apache.commons.codec.binary.Base64;
 
 
-public class CouchDbAuthUtils {
+public final class CouchDbAuthUtils {
 
   private final Environment environment;
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtils.java
@@ -21,6 +21,13 @@ import org.apache.streampipes.commons.environment.Environment;
 
 import org.apache.commons.codec.binary.Base64;
 
+/**
+ * Utility class for handling CouchDB authentication.
+ * <p>
+ * Provides helper methods to construct authentication information, including
+ * generation of the value for HTTP Basic Authentication headers based on
+ * CouchDB credentials obtained from the {@link Environment}.
+ */
 
 public final class CouchDbAuthUtils {
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+import org.apache.streampipes.storage.couchdb.serializer.GsonSerializer;
+
+import org.lightcouch.CouchDbClient;
+
+
+
+public class CouchDbClientFactory {
+
+  private final CouchDbPropertiesFactory propertiesFactory;
+
+  public CouchDbClientFactory(CouchDbPropertiesFactory propertiesFactory) {
+    this.propertiesFactory = propertiesFactory;
+  }
+
+  public CouchDbClient createGsonClient(String dbName) {
+    CouchDbClient client = new CouchDbClient(propertiesFactory.create(dbName));
+    client.setGsonBuilder(GsonSerializer.getGsonBuilder());
+    return client;
+  }
+
+  public CouchDbClient createPrincipalClient(String dbName) {
+    CouchDbClient client = new CouchDbClient(propertiesFactory.create(dbName));
+    client.setGsonBuilder(GsonSerializer.getPrincipalGsonBuilder());
+    return client;
+  }
+
+  public CouchDbClient createAdapterClient(String dbName) {
+    CouchDbClient client = new CouchDbClient(propertiesFactory.create(dbName));
+    client.setGsonBuilder(GsonSerializer.getAdapterGsonBuilder());
+    return client;
+  }
+
+  public CouchDbClient createDefaultClient(String dbName) {
+    return new CouchDbClient(propertiesFactory.create(dbName));
+  }
+}
+

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
@@ -21,7 +21,20 @@ import org.apache.streampipes.storage.couchdb.serializer.GsonSerializer;
 
 import org.lightcouch.CouchDbClient;
 
-
+/**
+ * Factory class for creating {@link CouchDbClient} instances configured with different
+ * Gson serialization strategies.
+ * <p>
+ * Uses a {@link CouchDbPropertiesFactory} to build the connection properties for the
+ * given database name and then configures the corresponding {@link CouchDbClient}.
+ * The factory provides specialized clients for:
+ * <ul>
+ *   <li>generic Gson serialization ({@link #createGsonClient(String)})</li>
+ *   <li>principal-aware serialization ({@link #createPrincipalClient(String)})</li>
+ *   <li>adapter-specific serialization ({@link #createAdapterClient(String)})</li>
+ *   <li>the default CouchDbClient configuration ({@link #createDefaultClient(String)})</li>
+ * </ul>
+ */
 
 public final class CouchDbClientFactory {
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactory.java
@@ -23,7 +23,7 @@ import org.lightcouch.CouchDbClient;
 
 
 
-public class CouchDbClientFactory {
+public final class CouchDbClientFactory {
 
   private final CouchDbPropertiesFactory propertiesFactory;
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
@@ -18,6 +18,14 @@
 
 package org.apache.streampipes.storage.couchdb.utils;
 
+/**
+ * Constants for CouchDB database names used throughout the storage layer.
+ *
+ * <p>This class centralizes database name definitions to avoid duplication
+ * and ensure consistency across CouchDB-related components.
+ */
+
+
 public final class CouchDbConstants {
   public static final String USER_DB_NAME = "users";
   public static final String DATA_LAKE_DB_NAME = "data-lake";

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+public final class CouchDbConstants {
+  public static final String USER_DB_NAME = "users";
+  public static final String DATA_LAKE_DB_NAME = "data-lake";
+}
+

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbConstants.java
@@ -29,5 +29,9 @@ package org.apache.streampipes.storage.couchdb.utils;
 public final class CouchDbConstants {
   public static final String USER_DB_NAME = "users";
   public static final String DATA_LAKE_DB_NAME = "data-lake";
+
+  private CouchDbConstants() {
+    // utility class
+  }
 }
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
@@ -21,6 +21,15 @@ import org.apache.streampipes.commons.environment.Environment;
 
 import org.lightcouch.CouchDbProperties;
 
+/**
+ * Factory class for creating {@link CouchDbProperties} instances based on
+ * CouchDB configuration provided by the {@link Environment}.
+ *
+ * <p>The factory reads protocol, host, port, username and password from the
+ * environment and uses these values to create {@code CouchDbProperties}
+ * for a given database name. It can optionally mark the database to be
+ * created if it does not already exist.</p>
+ */
 
 public class CouchDbPropertiesFactory {
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+import org.apache.streampipes.commons.environment.Environment;
+
+import org.lightcouch.CouchDbProperties;
+
+
+public class CouchDbPropertiesFactory {
+
+  private final Environment environment;
+
+  public CouchDbPropertiesFactory(Environment environment) {
+    this.environment = environment;
+  }
+
+  public CouchDbProperties create(String dbName, boolean createIfNotExists) {
+    return new CouchDbProperties(
+        dbName,
+        createIfNotExists,
+        environment.getCouchDbProtocol().getValueOrDefault(),
+        environment.getCouchDbHost().getValueOrDefault(),
+        environment.getCouchDbPort().getValueOrDefault(),
+        environment.getCouchDbUsername().getValueOrDefault(),
+        environment.getCouchDbPassword().getValueOrDefault());
+  }
+
+  public CouchDbProperties create(String dbName) {
+    return create(dbName, true);
+  }
+}
+

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactory.java
@@ -31,7 +31,7 @@ import org.lightcouch.CouchDbProperties;
  * created if it does not already exist.</p>
  */
 
-public class CouchDbPropertiesFactory {
+public final class CouchDbPropertiesFactory {
 
   private final Environment environment;
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+
+
+public class CouchDbRequestFactory {
+
+  private final CouchDbAuthUtils authUtils;
+
+  public CouchDbRequestFactory(CouchDbAuthUtils authUtils) {
+    this.authUtils = authUtils;
+  }
+
+  public Request get(String route) {
+    return append(Request.Get(route));
+  }
+
+  public Request post(String route, String payload) {
+    return append(Request.Post(route)
+        .bodyString(payload, ContentType.APPLICATION_JSON));
+  }
+
+  public Request put(String route, String payload) {
+    return append(Request.Put(route)
+        .bodyString(payload, ContentType.APPLICATION_JSON));
+  }
+
+  public Request delete(String route) {
+    return append(Request.Delete(route));
+  }
+
+  private Request append(Request req) {
+    req.setHeader(HttpHeaders.AUTHORIZATION,
+            "Basic " + authUtils.getBasicAuthHeaderValue())
+        .connectTimeout(1000)
+        .socketTimeout(100000);
+    return req;
+  }
+}

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
@@ -21,6 +21,13 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
+/**
+ * Factory class for creating authenticated HTTP requests to CouchDB.
+ * <p>
+ * This utility centralizes the creation of {@link Request} instances with a
+ * preconfigured Basic Authorization header and connection/socket timeouts.
+ * It uses {@link CouchDbAuthUtils} to obtain the credentials for CouchDB.
+ */
 
 public final class CouchDbRequestFactory {
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactory.java
@@ -22,7 +22,7 @@ import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
 
 
-public class CouchDbRequestFactory {
+public final class CouchDbRequestFactory {
 
   private final CouchDbAuthUtils authUtils;
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtils.java
@@ -21,7 +21,12 @@ import org.apache.streampipes.commons.environment.Environment;
 
 import com.google.common.net.UrlEscapers;
 
-
+/**
+ * Utility class for working with CouchDB URLs.
+ * <p>
+ * Provides helper methods to escape URL path segments and to construct
+ * CouchDB database routes from the configured {@link Environment}.
+ */
 
 public final class CouchDbUrlUtils {
 

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+import org.apache.streampipes.commons.environment.Environment;
+
+import com.google.common.net.UrlEscapers;
+
+
+
+public final class CouchDbUrlUtils {
+
+  private CouchDbUrlUtils() {}
+
+  public static String escapePathSegment(String segment) {
+    return UrlEscapers.urlPathSegmentEscaper().escape(segment);
+  }
+
+  public static String buildDatabaseRoute(Environment env, String dbName) {
+    return env.getCouchDbProtocol().getValueOrDefault()
+        + "://" + env.getCouchDbHost().getValueOrDefault()
+        + ":" + env.getCouchDbPort().getValueOrDefault()
+        + "/" + dbName;
+  }
+}

--- a/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/Utils.java
+++ b/streampipes-storage-couchdb/src/main/java/org/apache/streampipes/storage/couchdb/utils/Utils.java
@@ -30,6 +30,7 @@ import org.apache.http.entity.ContentType;
 import org.lightcouch.CouchDbClient;
 import org.lightcouch.CouchDbProperties;
 
+@Deprecated
 public class Utils {
 
   public static final String USER_DB_NAME = "users";

--- a/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtilsTest.java
+++ b/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbAuthUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+import org.apache.streampipes.commons.constants.Envs;
+import org.apache.streampipes.commons.environment.DefaultEnvironment;
+import org.apache.streampipes.commons.environment.variable.StringEnvironmentVariable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CouchDbAuthUtilsTest {
+
+  @Test
+  void testGetBasicAuthHeaderValue() {
+    TestEnvironment environment = new TestEnvironment("admin", "secret");
+
+    CouchDbAuthUtils authUtils = new CouchDbAuthUtils(environment);
+
+    String encodedAuth = authUtils.getBasicAuthHeaderValue();
+
+    assertEquals("YWRtaW46c2VjcmV0", encodedAuth);
+  }
+
+  private static class TestEnvironment extends DefaultEnvironment {
+    private final String username;
+    private final String password;
+
+    TestEnvironment(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbUsername() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_USER) {
+        @Override
+        public String getValueOrDefault() {
+          return username;
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbPassword() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PASSWORD) {
+        @Override
+        public String getValueOrDefault() {
+          return password;
+        }
+      };
+    }
+  }
+}

--- a/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactoryTest.java
+++ b/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbClientFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+import org.apache.streampipes.commons.constants.Envs;
+import org.apache.streampipes.commons.environment.DefaultEnvironment;
+import org.apache.streampipes.commons.environment.variable.IntEnvironmentVariable;
+import org.apache.streampipes.commons.environment.variable.StringEnvironmentVariable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CouchDbClientFactoryTest {
+
+  private static class TestEnvironment extends DefaultEnvironment {
+
+    @Override
+    public StringEnvironmentVariable getCouchDbProtocol() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PROTOCOL) {
+        @Override
+        public String getValueOrDefault() {
+          return "http";
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbHost() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_HOST) {
+        @Override
+        public String getValueOrDefault() {
+          return "localhost";
+        }
+      };
+    }
+
+    @Override
+    public IntEnvironmentVariable getCouchDbPort() {
+      return new IntEnvironmentVariable(Envs.SP_COUCHDB_PORT) {
+        @Override
+        public Integer getValueOrDefault() {
+          return 5984;
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbUsername() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_USER) {
+        @Override
+        public String getValueOrDefault() {
+          return "user";
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbPassword() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PASSWORD) {
+        @Override
+        public String getValueOrDefault() {
+          return "password";
+        }
+      };
+    }
+  }
+
+  @Test
+  void testFactoryCreation() {
+    CouchDbPropertiesFactory propertiesFactory = new CouchDbPropertiesFactory(new TestEnvironment());
+    CouchDbClientFactory factory = new CouchDbClientFactory(propertiesFactory);
+
+    assertNotNull(factory);
+    assertNotNull(propertiesFactory.create("test-db"));
+  }
+}

--- a/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactoryTest.java
+++ b/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbPropertiesFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+import org.apache.streampipes.commons.constants.Envs;
+import org.apache.streampipes.commons.environment.DefaultEnvironment;
+import org.apache.streampipes.commons.environment.variable.IntEnvironmentVariable;
+import org.apache.streampipes.commons.environment.variable.StringEnvironmentVariable;
+
+import org.junit.jupiter.api.Test;
+import org.lightcouch.CouchDbProperties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CouchDbPropertiesFactoryTest {
+
+  @Test
+  void testCreateProperties() {
+    TestEnvironment environment = new TestEnvironment();
+    CouchDbPropertiesFactory factory = new CouchDbPropertiesFactory(environment);
+
+    CouchDbProperties props = factory.create("test-db", true);
+
+    assertNotNull(props);
+    assertEquals("test-db", props.getDbName());
+    assertEquals("localhost", props.getHost());
+    assertEquals(5984, props.getPort());
+  }
+
+  private static class TestEnvironment extends DefaultEnvironment {
+
+    @Override
+    public StringEnvironmentVariable getCouchDbProtocol() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PROTOCOL) {
+        @Override
+        public String getValueOrDefault() {
+          return "http";
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbHost() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_HOST) {
+        @Override
+        public String getValueOrDefault() {
+          return "localhost";
+        }
+      };
+    }
+
+    @Override
+    public IntEnvironmentVariable getCouchDbPort() {
+      return new IntEnvironmentVariable(Envs.SP_COUCHDB_PORT) {
+        @Override
+        public Integer getValueOrDefault() {
+          return 5984;
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbUsername() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_USER) {
+        @Override
+        public String getValueOrDefault() {
+          return "admin";
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbPassword() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PASSWORD) {
+        @Override
+        public String getValueOrDefault() {
+          return "secret";
+        }
+      };
+    }
+  }
+}

--- a/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactoryTest.java
+++ b/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbRequestFactoryTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+import org.apache.streampipes.commons.constants.Envs;
+import org.apache.streampipes.commons.environment.DefaultEnvironment;
+import org.apache.streampipes.commons.environment.variable.StringEnvironmentVariable;
+
+import org.apache.http.client.fluent.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CouchDbRequestFactoryTest {
+
+  private CouchDbRequestFactory factory;
+
+  @BeforeEach
+  void setUp() {
+    var environment = new TestEnvironment("admin", "password");
+    var authUtils = new CouchDbAuthUtils(environment);
+    factory = new CouchDbRequestFactory(authUtils);
+  }
+
+  @Test
+  void testGetRequestReturnsNonNullRequest() {
+    Request request = factory.get("http://localhost/test");
+
+    assertNotNull(request);
+  }
+
+  @Test
+  void testPostRequestReturnsNonNullRequest() {
+    Request request = factory.post("http://localhost/test", "{}");
+
+    assertNotNull(request);
+  }
+
+  @Test
+  void testPutRequestReturnsNonNullRequest() {
+    Request request = factory.put("http://localhost/test", "{}");
+
+    assertNotNull(request);
+  }
+
+  @Test
+  void testDeleteRequestReturnsNonNullRequest() {
+    Request request = factory.delete("http://localhost/test");
+
+    assertNotNull(request);
+  }
+
+  private static class TestEnvironment extends DefaultEnvironment {
+    private final String username;
+    private final String password;
+
+    TestEnvironment(String username, String password) {
+      this.username = username;
+      this.password = password;
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbUsername() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_USER) {
+        @Override
+        public String getValueOrDefault() {
+          return username;
+        }
+      };
+    }
+
+    @Override
+    public StringEnvironmentVariable getCouchDbPassword() {
+      return new StringEnvironmentVariable(Envs.SP_COUCHDB_PASSWORD) {
+        @Override
+        public String getValueOrDefault() {
+          return password;
+        }
+      };
+    }
+  }
+}

--- a/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtilsTest.java
+++ b/streampipes-storage-couchdb/src/test/java/org/apache/streampipes/storage/couchdb/utils/CouchDbUrlUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.storage.couchdb.utils;
+
+import org.apache.streampipes.commons.environment.DefaultEnvironment;
+import org.apache.streampipes.commons.environment.Environment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CouchDbUrlUtilsTest {
+
+  @Test
+  void testEscapePathSegment() {
+    assertEquals("my%20db", CouchDbUrlUtils.escapePathSegment("my db"));
+    assertEquals("a%2Fb", CouchDbUrlUtils.escapePathSegment("a/b"));
+    assertEquals("simple", CouchDbUrlUtils.escapePathSegment("simple"));
+  }
+
+  @Test
+  void testBuildDatabaseRouteWithDefaultEnvironment() {
+    Environment env = new DefaultEnvironment();
+
+    String route = CouchDbUrlUtils.buildDatabaseRoute(env, "testdb");
+
+    // Verify the route is constructed correctly using the default environment values
+    assertNotNull(route);
+    // The route should end with the database name
+    assertEquals(
+        env.getCouchDbProtocol().getValueOrDefault()
+            + "://" + env.getCouchDbHost().getValueOrDefault()
+            + ":" + env.getCouchDbPort().getValueOrDefault()
+            + "/testdb",
+        route
+    );
+  }
+
+  @Test
+  void testBuildDatabaseRouteFormat() {
+    Environment env = new DefaultEnvironment();
+
+    String route = CouchDbUrlUtils.buildDatabaseRoute(env, "my-database");
+
+    // Verify the route contains expected URL components
+    assertNotNull(route);
+    assertTrue(route.contains("://"));
+    assertTrue(route.endsWith("/my-database"));
+  }
+}


### PR DESCRIPTION
### Purpose
FIxes #2178 
This PR refactors the former `Utils` class in the `streampipes-storage-couchdb` module
into multiple focused utility and factory classes.

The previous `Utils` class bundled a wide range of responsibilities such as environment
access, authentication handling, URL construction, HTTP request creation, and CouchDB
client configuration, which made it hard to test and maintain.

This refactoring splits these concerns into dedicated classes:
- `CouchDbConstants`
- `CouchDbUrlUtils`
- `CouchDbAuthUtils`
- `CouchDbPropertiesFactory`
- `CouchDbClientFactory`
- `CouchDbRequestFactory`

The original `Utils` class has been marked as deprecated and now delegates to the new
utility classes to ensure backward compatibility.

No functional behavior has been changed.

---

### Remarks
- This change improves separation of concerns and testability of CouchDB-related utilities.
- The refactoring is fully backward compatible through delegation in the deprecated `Utils` class.
- No migration steps are required for existing code.

PR introduces (a) breaking change(s): **no**

PR introduces (a) deprecation(s): **yes**
