### PR TITLE
[#3985] Rename remaining data-explorer UI references to chart

### DIFF
--- a/ui/src/app/chart-shared/components/charts/base/echarts-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/base/echarts-widget.component.ts
@@ -31,7 +31,7 @@ import { debounceTime } from 'rxjs/operators';
 import { ResizeEchartsService } from '../../../services/resize-echarts.service';
 
 @Component({
-    selector: 'sp-data-explorer-echarts-widget',
+    selector: 'sp-chart-echarts-widget',
     templateUrl: './echarts-widget.component.html',
     styleUrls: ['./echarts-widget.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/correlation-chart/config/correlation-chart-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/correlation-chart/config/correlation-chart-widget-config.component.ts
@@ -25,7 +25,7 @@ import {
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-correlation-chart-widget-config',
+    selector: 'sp-chart-correlation-chart-widget-config',
     templateUrl: './correlation-chart-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/gauge/config/gauge-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/gauge/config/gauge-widget-config.component.ts
@@ -24,7 +24,7 @@ import { GaugeVisConfig, GaugeWidgetModel } from '../model/gauge-widget.model';
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-gauge-widget-config',
+    selector: 'sp-chart-gauge-widget-config',
     templateUrl: './gauge-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/heatmap/config/heatmap-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/heatmap/config/heatmap-widget-config.component.ts
@@ -27,7 +27,7 @@ import { ChartFieldProviderService } from '../../../../services/chart-field-prov
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-heatmap-widget-config',
+    selector: 'sp-chart-heatmap-widget-config',
     templateUrl: './heatmap-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/image/config/image-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/image/config/image-widget-config.component.ts
@@ -25,7 +25,7 @@ import {
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-image-widget-config',
+    selector: 'sp-chart-image-widget-config',
     templateUrl: './image-widget-config.component.html',
     styleUrls: ['./image-widget-config.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/image/image-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/image/image-widget.component.ts
@@ -28,7 +28,7 @@ import { ImageWidgetModel } from './model/image-widget.model';
 import { SecurePipe } from '../../../../services/secure.pipe';
 
 @Component({
-    selector: 'sp-data-explorer-image-widget',
+    selector: 'sp-chart-image-widget',
     templateUrl: './image-widget.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/indicator/config/indicator-chart-widget-config.component.html
+++ b/ui/src/app/chart-shared/components/charts/indicator/config/indicator-chart-widget-config.component.html
@@ -33,7 +33,7 @@
     </sp-split-section>
     <sp-split-section [level]="3" [title]="'Settings' | translate">
         <mat-checkbox
-            data-cy="data-explorer-select-delta-checkbox"
+            data-cy="chart-select-delta-checkbox"
             (change)="updateDelta($event)"
             [(ngModel)]="
                 currentlyConfiguredWidget.visualizationConfig.showDelta

--- a/ui/src/app/chart-shared/components/charts/indicator/config/indicator-chart-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/indicator/config/indicator-chart-widget-config.component.ts
@@ -26,7 +26,7 @@ import { DataExplorerField } from '@streampipes/platform-services';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
-    selector: 'sp-data-explorer-indicator-chart-widget-config',
+    selector: 'sp-chart-indicator-chart-widget-config',
     templateUrl: './indicator-chart-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/map/config/map-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/map/config/map-widget-config.component.ts
@@ -25,7 +25,7 @@ import { DataExplorerField } from '@streampipes/platform-services';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
-    selector: 'sp-data-explorer-map-widget-config',
+    selector: 'sp-chart-map-widget-config',
     templateUrl: './map-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/map/map-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/map/map-widget.component.ts
@@ -41,7 +41,7 @@ import {
 import { MapLayerProviderService } from '../../../../core-ui/services/map-layer-provider.service';
 
 @Component({
-    selector: 'sp-data-explorer-map-widget',
+    selector: 'sp-chart-map-widget',
     templateUrl: './map-widget.component.html',
     styleUrls: ['./map-widget.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/status-heatmap/config/status-heatmap-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/status-heatmap/config/status-heatmap-widget-config.component.ts
@@ -27,7 +27,7 @@ import { ChartFieldProviderService } from '../../../../services/chart-field-prov
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-status-heatmap-widget-config',
+    selector: 'sp-chart-status-heatmap-widget-config',
     templateUrl: './status-heatmap-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/status/config/status-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/status/config/status-widget-config.component.ts
@@ -27,7 +27,7 @@ import { ChartFieldProviderService } from '../../../../services/chart-field-prov
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-status-widget-config',
+    selector: 'sp-chart-status-widget-config',
     templateUrl: './status-widget-config.component.html',
     styleUrls: ['./status-widget-config.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/status/status-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/status/status-widget.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-status-widget',
+    selector: 'sp-chart-status-widget',
     templateUrl: './status-widget.component.html',
     styleUrls: ['./status-widget.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/table/config/table-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/table/config/table-widget-config.component.ts
@@ -24,7 +24,7 @@ import { ChartFieldProviderService } from '../../../../services/chart-field-prov
 import { DataExplorerField } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-table-widget-config',
+    selector: 'sp-chart-table-widget-config',
     templateUrl: './table-widget-config.component.html',
     styleUrls: ['./table-widget-config.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/table/table-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/table/table-widget.component.ts
@@ -28,7 +28,7 @@ import {
 import { MatPaginator } from '@angular/material/paginator';
 
 @Component({
-    selector: 'sp-data-explorer-table-widget',
+    selector: 'sp-chart-table-widget',
     templateUrl: './table-widget.component.html',
     styleUrls: ['./table-widget.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/time-series-chart/config/time-series-chart-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/time-series-chart/config/time-series-chart-widget-config.component.ts
@@ -27,7 +27,7 @@ import { DataExplorerField } from '@streampipes/platform-services';
 import { ChartFieldProviderService } from '../../../../services/chart-field-provider.service';
 
 @Component({
-    selector: 'sp-data-explorer-time-series-chart-widget-config',
+    selector: 'sp-chart-time-series-chart-widget-config',
     templateUrl: './time-series-chart-widget-config.component.html',
     standalone: false,
 })

--- a/ui/src/app/chart-shared/components/charts/traffic-light/config/traffic-light-widget-config.component.ts
+++ b/ui/src/app/chart-shared/components/charts/traffic-light/config/traffic-light-widget-config.component.ts
@@ -28,7 +28,7 @@ import { DataExplorerField } from '@streampipes/platform-services';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
-    selector: 'sp-data-explorer-traffic-light-widget-config',
+    selector: 'sp-chart-traffic-light-widget-config',
     templateUrl: './traffic-light-widget-config.component.html',
     styleUrls: ['./traffic-light-widget-config.component.scss'],
     standalone: false,

--- a/ui/src/app/chart-shared/components/charts/traffic-light/traffic-light-widget.component.ts
+++ b/ui/src/app/chart-shared/components/charts/traffic-light/traffic-light-widget.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@streampipes/platform-services';
 
 @Component({
-    selector: 'sp-data-explorer-traffic-light-widget',
+    selector: 'sp-chart-traffic-light-widget',
     templateUrl: './traffic-light-widget.component.html',
     styleUrls: ['./traffic-light-widget.component.scss'],
     standalone: false,

--- a/ui/src/app/chart/components/chart-overview/chart-overview-table/chart-overview-table.component.ts
+++ b/ui/src/app/chart/components/chart-overview/chart-overview-table/chart-overview-table.component.ts
@@ -35,7 +35,7 @@ import { Subscription } from 'rxjs';
 import { MatSort } from '@angular/material/sort';
 
 @Component({
-    selector: 'sp-data-explorer-overview-table',
+    selector: 'sp-chart-overview-table',
     templateUrl: './chart-overview-table.component.html',
     styleUrls: ['../chart-overview.component.scss'],
     standalone: false,

--- a/ui/src/app/chart/components/chart-overview/chart-overview.component.html
+++ b/ui/src/app/chart/components/chart-overview/chart-overview.component.html
@@ -39,8 +39,8 @@
         }
     </div>
     <div fxFlex="100" fxLayout="column">
-        <sp-data-explorer-overview-table
+        <sp-chart-overview-table
             [hasDataExplorerWritePrivileges]="hasDataExplorerWritePrivileges"
-        ></sp-data-explorer-overview-table>
+        ></sp-chart-overview-table>
     </div>
 </sp-basic-view>

--- a/ui/src/app/dashboard-shared/components/chart-view/abstract-chart-view.directive.ts
+++ b/ui/src/app/dashboard-shared/components/chart-view/abstract-chart-view.directive.ts
@@ -58,7 +58,7 @@ export abstract class AbstractChartViewDirective {
     widgetsVisible = true;
 
     /**
-     * This is the date range (start, end) to view the data and is set in chart.ts
+     * This is the date range (start, end) to view the data and is set in chart-view.component.ts
      */
     @Input()
     timeSettings: TimeSettings;

--- a/ui/src/app/dashboard-shared/components/chart-view/abstract-chart-view.directive.ts
+++ b/ui/src/app/dashboard-shared/components/chart-view/abstract-chart-view.directive.ts
@@ -58,7 +58,7 @@ export abstract class AbstractChartViewDirective {
     widgetsVisible = true;
 
     /**
-     * This is the date range (start, end) to view the data and is set in data-explorer.ts
+     * This is the date range (start, end) to view the data and is set in chart.ts
      */
     @Input()
     timeSettings: TimeSettings;


### PR DESCRIPTION
### Purpose
This PR completes the UI refactor from `data-explorer` to `chart` by updating all remaining
UI references that were not covered by the initial module rename.

The changes ensure consistent naming across the UI by:
- Renaming Angular selectors from `sp-data-explorer-*` to `sp-chart-*`
- Updating chart widget and config components (table, image, status, gauge, map, traffic-light,
  time-series, correlation, heatmap, indicator, and shared base widgets)
- Cleaning up remaining `data-explorer` references in UI comments and test (`data-cy`) attributes

This aligns the UI codebase with the already renamed `chart` module and avoids confusion caused
by outdated naming.

### Remarks
- This PR contains UI-only refactoring and does not change runtime behavior or business logic.
- No backend, API, or data model changes are included.
- Changes were applied incrementally using small, focused commits to simplify review.

Related issues:
- Fixes #3985
- Relates to #4021

PR introduces (a) breaking change(s): **no**

PR introduces (a) deprecation(s): **no**
