### PR TITLE
fix(#4101): Increase precision for correction value transformation migration

### DIFF
--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/AdapterRuleConverter.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/AdapterRuleConverter.java
@@ -130,7 +130,7 @@ public class AdapterRuleConverter {
     }
 
     var symbols = new DecimalFormatSymbols(Locale.US);
-    var df = new DecimalFormat("0.###", symbols);
+    var df = new DecimalFormat("0.########################", symbols);
     var formattedValue = df.format(rule.getCorrectionValue());
 
     scriptBuilder.appendLine(String.format("event['%s'] = Number(event['%s']) %s %s;",

--- a/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
+++ b/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
@@ -190,6 +190,24 @@ class MigrateAdaptersToUseScriptTest {
   }
 
   @Test
+  void executeMigration_TransformsCorrectionValueRuleWithVerySmallNumber() throws IOException {
+    CorrectionValueTransformationRuleDescription rule = new CorrectionValueTransformationRuleDescription();
+    rule.setRuntimeKey("temperature");
+    rule.setOperator("MULTIPLY");
+    rule.setCorrectionValue(0.000000000000000000001);
+
+    var adapter = createBaseAdapter(rule);
+    when(mockStorage.findAll()).thenReturn(List.of(adapter));
+
+    migration.executeMigration();
+
+    var script = adapter.getTransformationConfig().getScript();
+    assertTrue(script.contains("event['temperature'] = Number(event['temperature']) * 0.000000000000000000001"));
+    assertTrue(adapter.getTransformationConfig().isScriptActive());
+  }
+
+
+  @Test
   void executeMigration_TransformsRegexRule() throws IOException {
     RegexTransformationRuleDescription rule = new RegexTransformationRuleDescription();
     rule.setRuntimeKey("deviceId");


### PR DESCRIPTION

<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
This PR addresses an issue where the migration of `CorrectionValueTransformationRuleDescription` caused precision loss for small positive values. The `DecimalFormat` pattern previously used a limited number of decimal places, causing values like `0.00001` to be rounded to `0`.

**Changes**

Updated the `DecimalFormat` pattern from `0.###` to `0.########################` to ensure high-precision decimals are preserved during the transformation.


### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
