### PR TITLE
#4113  Msteams sink error handling

### DIFF
--- a/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/msteams/MSTeamsSink.java
+++ b/streampipes-extensions/streampipes-sinks-notifications-jvm/src/main/java/org/apache/streampipes/sinks/notifications/jvm/msteams/MSTeamsSink.java
@@ -39,15 +39,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.Header;
+import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 
 public class MSTeamsSink extends StreamPipesNotificationSink {
 
@@ -65,12 +69,15 @@ public class MSTeamsSink extends StreamPipesNotificationSink {
   public static final String KEY_PROXY_GROUP = "proxyConfigurationGroup";
   public static final String KEY_PROXY_URL = "proxyUrl";
   protected static final String SIMPLE_MESSAGE_TEMPLATE = "{\"text\": \"%s\"}";
+  private static final int MAX_RETRIES = 5;
+  private static final int HTTP_TOO_MANY_REQUESTS = 429;
+  private static final Duration BASE_BACKOFF = Duration.ofSeconds(1);
 
   private String messageContent;
   private boolean isSimpleMessageMode;
   private String webhookUrl;
   private ObjectMapper objectMapper;
-  private HttpClient httpClient;
+  private CloseableHttpClient httpClient;
 
   public MSTeamsSink() {
     super();
@@ -174,7 +181,12 @@ public class MSTeamsSink extends StreamPipesNotificationSink {
 
   @Override
   public void onDetach() {
-    // nothing to do
+    try {
+      this.httpClient.close();
+    }
+    catch (IOException e) {
+      throw new SpRuntimeException("Error when closing MSTeams client: %s".formatted(e.getMessage()));
+    }
   }
 
   /**
@@ -226,26 +238,58 @@ public class MSTeamsSink extends StreamPipesNotificationSink {
    * @throws SpRuntimeException If an I/O error occurs while sending the payload to the webhook or
    *                            the payload sent is not accepted by the API.
    */
-  protected void sendPayloadToWebhook(HttpClient httpClient, String payload, String webhookUrl) {
-    try {
-      var contentEntity = new StringEntity(payload);
-      contentEntity.setContentType(ContentType.APPLICATION_JSON.toString());
+  protected void sendPayloadToWebhook(CloseableHttpClient httpClient, String payload, String webhookUrl) {
 
-      var postRequest = new HttpPost(webhookUrl);
-      postRequest.setEntity(contentEntity);
+    for (int attempt = 1; ; attempt++) {
+      HttpPost request = new HttpPost(webhookUrl);
+      request.setEntity(new StringEntity(payload, ContentType.APPLICATION_JSON));
 
-      var result = httpClient.execute(postRequest);
-      if (result.getStatusLine()
-          .getStatusCode() == HttpStatus.SC_BAD_REQUEST) {
-        throw new SpRuntimeException(
-            "The provided message payload was not accepted by the MS Teams API: %s"
-                .formatted(payload)
-        );
+      if (Thread.currentThread().isInterrupted()) {
+        throw new SpRuntimeException("Interrupted while sending MS Teams webhook");
       }
-    } catch (IOException e) {
-      throw new SpRuntimeException("Sending notification to MS Teams failed.", e);
+
+      try (CloseableHttpResponse response = httpClient.execute(request)) {
+
+        int status = response.getStatusLine().getStatusCode();
+
+        if (status >= 200 && status < 300) {
+          return;
+        }
+
+        if (status != HTTP_TOO_MANY_REQUESTS && (status < 500 || status >= 600)) {
+          throw new SpRuntimeException("MS Teams webhook rejected request (status=%d)".formatted(status));
+        }
+
+        if (attempt > MAX_RETRIES) {
+          throw new SpRuntimeException("MS Teams webhook failed after %d attempts (status=%d)"
+            .formatted(attempt - 1, status));
+        }
+
+        long backoffMs = BASE_BACKOFF.toMillis() << Math.min(attempt, 6);
+
+        Header retryAfter = response.getFirstHeader("Retry-After");
+        if (retryAfter != null) {
+          try {
+            backoffMs = Long.parseLong(retryAfter.getValue()) * 1000;
+          } catch (NumberFormatException ignored) {}
+        }
+
+        Thread.sleep(backoffMs);
+      } catch (IOException | InterruptedException e) {
+        if (attempt > MAX_RETRIES) {
+          throw new SpRuntimeException("I/O error sending MS Teams webhook", e);
+        }
+
+        try {
+          Thread.sleep(BASE_BACKOFF.toMillis() << Math.min(attempt, 6));
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          throw new SpRuntimeException("Interrupted while retrying MS Teams webhook", ie);
+        }
+      }
     }
   }
+
 
   /**
    * Validates a webhook URL to ensure it is not null, not empty, and has a valid URL format.

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,14 +17,6 @@ FROM nginx:mainline-alpine3.18
 
 COPY dist/streampipes/ui/browser/ /usr/share/nginx/html/
 
-#Store a copy to have a version if the other is hidden in the volume. Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
-RUN mkdir -p /etc/opt/nginx/
-RUN chown -R nginx:nginx /etc/opt/nginx/
-COPY nginx_config/default.conf.template /etc/opt/nginx/default.conf.template
-RUN chown -R nginx:nginx  /etc/opt/nginx/default.conf.template
-
-
-
 RUN chown -R nginx:nginx /usr/share/nginx/html && chmod -R 755 /usr/share/nginx/html && \
         chown -R nginx:nginx /var/cache/nginx && \
         chown -R nginx:nginx /var/log/nginx && \

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -19,14 +19,6 @@ if [ ! -z "$NGINX_SSL" ] && [ "$NGINX_SSL" = "true" ]; then
     rm /etc/nginx/conf.d/default.conf
     ln -s /app/nginx-confs/ssl.conf /etc/nginx/conf.d/default.conf
 elif [ ! -z "$SP_HTTP_SERVER_ADAPTER_ENDPOINT" ]; then
-
-    if [ ! -f /etc/nginx/conf.d/default.conf ]
-    then
-        DEFAULT_CONF_BACKUP="/etc/nginx/conf.d/default.conf_$(date +%s).bak"
-        echo "Create backup of old configuration $DEFAULT_CONF_BACKUP"
-        cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
-    fi
-
     rm  -f /etc/nginx/conf.d/default.conf
     envsubst '\$SP_HTTP_SERVER_ADAPTER_ENDPOINT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -27,13 +27,6 @@ elif [ ! -z "$SP_HTTP_SERVER_ADAPTER_ENDPOINT" ]; then
         cp /etc/nginx/conf.d/default.conf $DEFAULT_CONF_BACKUP
     fi
 
-    # Required for migration from 0.93.0 to 0.95.0. Could be removed after the release of 0.95.0.
-    if [ ! -f /etc/nginx/conf.d/default.conf.template ]
-    then
-        echo "Migrate to new nginx template"
-        cp /etc/opt/nginx/default.conf.template /etc/nginx/conf.d/default.conf.template
-    fi
-
     rm  -f /etc/nginx/conf.d/default.conf
     envsubst '\$SP_HTTP_SERVER_ADAPTER_ENDPOINT' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
 fi


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

I found some possible improvements of the MS Teams sink.

 -   Close HTTP responses to prevent hanging connections / connection leaks
 -   Add retry logic (with backoff) when the MS Teams webhook rate limit is hit (HTTP 429)
 -   Throw an exception when message delivery fails (non-2xx response after retries)



PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
