### PR TITLE
feat(plc4x-s7): support inline // comments in PLC4X S7 advanced configuration

### DIFF
--- a/streampipes-extensions/streampipes-connectors-plc/src/main/java/org/apache/streampipes/extensions/connectors/plc/adapter/s7/config/ConfigurationParser.java
+++ b/streampipes-extensions/streampipes-connectors-plc/src/main/java/org/apache/streampipes/extensions/connectors/plc/adapter/s7/config/ConfigurationParser.java
@@ -49,20 +49,27 @@ public class ConfigurationParser {
       // Remove leading and trailing whitespace
       line = line.trim();
 
-      // Skip comments
-      if (line.startsWith("//")) {
+      // Skip empty lines and full-line comments
+      if (line.isEmpty() || line.startsWith("//")) {
         continue;
       }
 
-      // Check if macher matches and add to results list
+      // Strip inline comments
+      int commentIndex = line.indexOf("//");
+      if (commentIndex >= 0) {
+        line = line.substring(0, commentIndex).trim();
+      }
+
+      // Check if matcher matches and add to results list
       var matcher = pattern.matcher(line);
       if (matcher.find()) {
         result.put(matcher.group(1), matcher.group(2));
       }
     }
-
     return result;
   }
+
+  
 
 
   /**

--- a/streampipes-extensions/streampipes-connectors-plc/src/test/java/org/apache/streampipes/extensions/connectors/plc/adapter/s7/config/ConfigurationParserTest.java
+++ b/streampipes-extensions/streampipes-connectors-plc/src/test/java/org/apache/streampipes/extensions/connectors/plc/adapter/s7/config/ConfigurationParserTest.java
@@ -68,13 +68,26 @@ public class ConfigurationParserTest {
     assertEquals("%I0.2:STRING(10)", result.get("v3"));
     assertEquals("%I0.3:STRING(10)[100]", result.get("v4"));
   }
-
+  
   @Test
   public void getNodeInformationFromCodeProperty_NoEntries() {
     var configBlock = "";
     var result = new ConfigurationParser().getNodeInformationFromCodeProperty(configBlock);
 
     assertEquals(0, result.size());
+  }
+  
+  @Test
+  public void getNodeInformationFromCodeProperty_InlineComment() {
+    var configBlock = """
+        temperature=%DB1281:0:REAL // inline comment
+        """;
+
+    var result = new ConfigurationParser().getNodeInformationFromCodeProperty(configBlock);
+
+    assertEquals(1, result.size());
+    assertEquals(Set.of("temperature"), result.keySet());
+    assertEquals("%DB1281:0:REAL", result.get("temperature"));
   }
 
   @Test

--- a/ui/src/app/services/tour/adapter-tour.constants.ts
+++ b/ui/src/app/services/tour/adapter-tour.constants.ts
@@ -99,14 +99,6 @@ export default {
             },
             {
                 stepId: 'step-11',
-                title: 'Transform events using a script',
-                text: '<p>You can optionally transform incoming events using a custom script. This allows you to modify, enrich, or add fields to the event before it is processed further.</p><p>Click <b>Next</b> to continue.</p>',
-                attachToElement: '[data-cy="connect-event-transform-script"]',
-                attachPosition: 'top',
-                buttons: ['cancel', 'next'],
-            },
-            {
-                stepId: 'step-12',
                 title: 'Go to next step',
                 text: 'Finish the modelling and go to next step to start the adapter. Click <b>next</b> to continue.',
                 attachToElement: '[data-cy="sp-event-schema-next-button"]',
@@ -114,7 +106,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-13',
+                stepId: 'step-12',
                 title: 'Adapter name',
                 text: 'Change the name of the adapter to <b>Tutorial</b> and click outside the input field to continue.',
                 attachToElement: '[data-cy="sp-adapter-name"]',
@@ -122,7 +114,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-14',
+                stepId: 'step-13',
                 title: 'Persistence',
                 text: 'Check the <b>Persist</b> option to persist all messages that are produced by this adapter. Only persisted data can be visualized in the dashboard or inspected in the data lake. <br>You can also persist data later by using the pipeline editor. ',
                 attachToElement: '[data-cy="sp-store-in-datalake"]',
@@ -130,7 +122,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-15',
+                stepId: 'step-14',
                 title: 'Start Adapter',
                 text: "Now it's time to start our adapter! Click <b>Start adapter</b> to deploy the adapter.",
                 attachToElement:
@@ -139,7 +131,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-16',
+                stepId: 'step-15',
                 title: 'Congratulations',
                 text: '<b></b>Congratulations!</b> You have created your first adapter and finished the tutorial. Go to the pipeline editor to see the new data stream',
                 classes: 'shepherd shepherd-welcome',
@@ -156,13 +148,12 @@ export default {
             { actionId: 'adapter-edit-field-clicked', currentStep: 'step-7' },
             { actionId: 'adapter-runtime-name-changed', currentStep: 'step-8' },
             { actionId: 'adapter-field-changed', currentStep: 'step-9' },
-            { actionId: 'event-transform-script-next', currentStep: 'step-11' },
-            { actionId: 'event-schema-next-button', currentStep: 'step-12' },
-            { actionId: 'adapter-name-assigned', currentStep: 'step-13' },
-            { actionId: 'adapter-persist-selected', currentStep: 'step-14' },
+            { actionId: 'event-schema-next-button', currentStep: 'step-11' },
+            { actionId: 'adapter-name-assigned', currentStep: 'step-12' },
+            { actionId: 'adapter-persist-selected', currentStep: 'step-13' },
             {
                 actionId: 'adapter-settings-adapter-started',
-                currentStep: 'step-15',
+                currentStep: 'step-14',
             },
         ],
     },

--- a/ui/src/app/services/tour/adapter-tour.constants.ts
+++ b/ui/src/app/services/tour/adapter-tour.constants.ts
@@ -99,6 +99,14 @@ export default {
             },
             {
                 stepId: 'step-11',
+                title: 'Transform events using a script',
+                text: '<p>You can optionally transform incoming events using a custom script. This allows you to modify, enrich, or add fields to the event before it is processed further.</p><p>Click <b>Next</b> to continue.</p>',
+                attachToElement: '[data-cy="connect-event-transform-script"]',
+                attachPosition: 'top',
+                buttons: ['cancel', 'next'],
+            },
+            {
+                stepId: 'step-12',
                 title: 'Go to next step',
                 text: 'Finish the modelling and go to next step to start the adapter. Click <b>next</b> to continue.',
                 attachToElement: '[data-cy="sp-event-schema-next-button"]',
@@ -106,7 +114,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-12',
+                stepId: 'step-13',
                 title: 'Adapter name',
                 text: 'Change the name of the adapter to <b>Tutorial</b> and click outside the input field to continue.',
                 attachToElement: '[data-cy="sp-adapter-name"]',
@@ -114,7 +122,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-13',
+                stepId: 'step-14',
                 title: 'Persistence',
                 text: 'Check the <b>Persist</b> option to persist all messages that are produced by this adapter. Only persisted data can be visualized in the dashboard or inspected in the data lake. <br>You can also persist data later by using the pipeline editor. ',
                 attachToElement: '[data-cy="sp-store-in-datalake"]',
@@ -122,7 +130,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-14',
+                stepId: 'step-15',
                 title: 'Start Adapter',
                 text: "Now it's time to start our adapter! Click <b>Start adapter</b> to deploy the adapter.",
                 attachToElement:
@@ -131,7 +139,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-15',
+                stepId: 'step-16',
                 title: 'Congratulations',
                 text: '<b></b>Congratulations!</b> You have created your first adapter and finished the tutorial. Go to the pipeline editor to see the new data stream',
                 classes: 'shepherd shepherd-welcome',
@@ -148,12 +156,13 @@ export default {
             { actionId: 'adapter-edit-field-clicked', currentStep: 'step-7' },
             { actionId: 'adapter-runtime-name-changed', currentStep: 'step-8' },
             { actionId: 'adapter-field-changed', currentStep: 'step-9' },
-            { actionId: 'event-schema-next-button', currentStep: 'step-11' },
-            { actionId: 'adapter-name-assigned', currentStep: 'step-12' },
-            { actionId: 'adapter-persist-selected', currentStep: 'step-13' },
+            { actionId: 'event-transform-script-next', currentStep: 'step-11' },
+            { actionId: 'event-schema-next-button', currentStep: 'step-12' },
+            { actionId: 'adapter-name-assigned', currentStep: 'step-13' },
+            { actionId: 'adapter-persist-selected', currentStep: 'step-14' },
             {
                 actionId: 'adapter-settings-adapter-started',
-                currentStep: 'step-14',
+                currentStep: 'step-15',
             },
         ],
     },


### PR DESCRIPTION
This PR adds support for inline `//` comments in the PLC4X S7 advanced code block configuration.

Previously, comments placed at the end of a configuration line were treated as part of the PLC datatype, which caused parsing errors such as:
`Datatype %DB1281:0:REAL // comment is not supported`.

With this change, inline comments are stripped before parsing key/value pairs, while preserving support for full-line comments and existing configurations.
