### PR TITLE
[#4112] Fix adapter creation tour for event transform script step

### DIFF
--- a/ui/src/app/services/tour/adapter-tour.constants.ts
+++ b/ui/src/app/services/tour/adapter-tour.constants.ts
@@ -99,6 +99,14 @@ export default {
             },
             {
                 stepId: 'step-11',
+                title: 'Transform events using a script',
+                text: '<p>You can optionally transform incoming events using a custom script. This allows you to modify, enrich, or add fields to the event before it is processed further.</p><p>Click <b>Next</b> to continue.</p>',
+                attachToElement: '[data-cy="connect-event-transform-script"]',
+                attachPosition: 'top',
+                buttons: ['cancel', 'next'],
+            },
+            {
+                stepId: 'step-12',
                 title: 'Go to next step',
                 text: 'Finish the modelling and go to next step to start the adapter. Click <b>next</b> to continue.',
                 attachToElement: '[data-cy="sp-event-schema-next-button"]',
@@ -106,7 +114,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-12',
+                stepId: 'step-13',
                 title: 'Adapter name',
                 text: 'Change the name of the adapter to <b>Tutorial</b> and click outside the input field to continue.',
                 attachToElement: '[data-cy="sp-adapter-name"]',
@@ -114,7 +122,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-13',
+                stepId: 'step-14',
                 title: 'Persistence',
                 text: 'Check the <b>Persist</b> option to persist all messages that are produced by this adapter. Only persisted data can be visualized in the dashboard or inspected in the data lake. <br>You can also persist data later by using the pipeline editor. ',
                 attachToElement: '[data-cy="sp-store-in-datalake"]',
@@ -122,7 +130,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-14',
+                stepId: 'step-15',
                 title: 'Start Adapter',
                 text: "Now it's time to start our adapter! Click <b>Start adapter</b> to deploy the adapter.",
                 attachToElement:
@@ -131,7 +139,7 @@ export default {
                 buttons: ['cancel'],
             },
             {
-                stepId: 'step-15',
+                stepId: 'step-16',
                 title: 'Congratulations',
                 text: '<b></b>Congratulations!</b> You have created your first adapter and finished the tutorial. Go to the pipeline editor to see the new data stream',
                 classes: 'shepherd shepherd-welcome',
@@ -148,12 +156,13 @@ export default {
             { actionId: 'adapter-edit-field-clicked', currentStep: 'step-7' },
             { actionId: 'adapter-runtime-name-changed', currentStep: 'step-8' },
             { actionId: 'adapter-field-changed', currentStep: 'step-9' },
-            { actionId: 'event-schema-next-button', currentStep: 'step-11' },
-            { actionId: 'adapter-name-assigned', currentStep: 'step-12' },
-            { actionId: 'adapter-persist-selected', currentStep: 'step-13' },
+            { actionId: 'event-transform-script-next', currentStep: 'step-11' },
+            { actionId: 'event-schema-next-button', currentStep: 'step-12' },
+            { actionId: 'adapter-name-assigned', currentStep: 'step-13' },
+            { actionId: 'adapter-persist-selected', currentStep: 'step-14' },
             {
                 actionId: 'adapter-settings-adapter-started',
-                currentStep: 'step-14',
+                currentStep: 'step-15',
             },
         ],
     },


### PR DESCRIPTION
### Purpose

This PR updates the adapter creation Shepherd tour to align with the new adapter generation workflow.

A new step was introduced in the adapter creation process that allows users to transform incoming events using a script. The existing adapter tour did not include this step, which caused the tour to break during execution.

This change adds the missing tour step and updates the flow so the tutorial proceeds correctly with the current UI.

### Remarks

Only the Shepherd tour configuration was updated.

No functional UI or backend logic was modified.

Existing data-cy selectors were reused to remain compatible with Cypress tests.

PR introduces (a) breaking change(s): no  
PR introduces (a) deprecation(s): no
