### PR TITLE
Add multi-field rename processor

### DIFF
--- a/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/TransformationExtensionModuleExport.java
+++ b/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/TransformationExtensionModuleExport.java
@@ -17,7 +17,6 @@
  */
 
 package org.apache.streampipes.processors.transformation.jvm;
-
 import org.apache.streampipes.extensions.api.connect.StreamPipesAdapter;
 import org.apache.streampipes.extensions.api.declarer.IExtensionModuleExport;
 import org.apache.streampipes.extensions.api.migration.IModelMigrator;
@@ -36,6 +35,7 @@ import org.apache.streampipes.processors.transformation.jvm.processor.booloperat
 import org.apache.streampipes.processors.transformation.jvm.processor.csvmetadata.CsvMetadataEnrichmentProcessor;
 import org.apache.streampipes.processors.transformation.jvm.processor.datetime.DateTimeFromStringProcessor;
 import org.apache.streampipes.processors.transformation.jvm.processor.fieldrename.FiledRenameProcessor;
+import org.apache.streampipes.processors.transformation.jvm.processor.fieldrenamermulti.MultiFieldRenameRuntime;
 import org.apache.streampipes.processors.transformation.jvm.processor.hasher.FieldHasherProcessor;
 import org.apache.streampipes.processors.transformation.jvm.processor.mapper.FieldMapperProcessor;
 import org.apache.streampipes.processors.transformation.jvm.processor.measurementconverter.MeasurementUnitConverterProcessor;
@@ -65,39 +65,40 @@ public class TransformationExtensionModuleExport implements IExtensionModuleExpo
   }
 
   @Override
-  public List<IStreamPipesPipelineElement<?>> pipelineElements() {
-    return List.of(
-        new CountArrayProcessor(),
-        new SplitArrayProcessor(),
-        new CalculateDurationProcessor(),
-        new ChangedValueDetectionProcessor(),
-        new TimestampExtractorProcessor(),
-        new BooleanCounterProcessor(),
-        new BooleanInverterProcessor(),
-        new DateTimeFromStringProcessor(),
-        new BooleanTimekeepingProcessor(),
-        new BooleanTimerProcessor(),
-        new CsvMetadataEnrichmentProcessor(),
-        new FieldHasherProcessor(),
-        new FieldMapperProcessor(),
-        new MeasurementUnitConverterProcessor(),
-        new TaskDurationProcessor(),
-        new TransformToBooleanProcessor(),
-        new StaticMetaDataEnrichmentProcessor(),
-        new StringTimerProcessor(),
-        new SignalEdgeFilterProcessor(),
-        new SwitchOperatorBooleanInputProcessor(),
-        new SwitchOperatorStringInputProcessor(),
-        new SwitchOperatorNumericalInputProcessor(),
-        new BooleanToStateProcessor(),
-        new NumberLabelerProcessor(),
-        new StringToStateProcessor(),
-        new StringCounterProcessor(),
-        new BooleanOperatorProcessor(),
-        new FiledRenameProcessor(),
-        new RoundProcessor()
-        );
-  }
+public List<IStreamPipesPipelineElement<?>> pipelineElements() {
+  return List.of(
+      new CountArrayProcessor(),
+      new SplitArrayProcessor(),
+      new CalculateDurationProcessor(),
+      new ChangedValueDetectionProcessor(),
+      new TimestampExtractorProcessor(),
+      new BooleanCounterProcessor(),
+      new BooleanInverterProcessor(),
+      new DateTimeFromStringProcessor(),
+      new BooleanTimekeepingProcessor(),
+      new BooleanTimerProcessor(),
+      new CsvMetadataEnrichmentProcessor(),
+      new FieldHasherProcessor(),
+      new FieldMapperProcessor(),
+      new MeasurementUnitConverterProcessor(),
+      new TaskDurationProcessor(),
+      new TransformToBooleanProcessor(),
+      new StaticMetaDataEnrichmentProcessor(),
+      new StringTimerProcessor(),
+      new SignalEdgeFilterProcessor(),
+      new SwitchOperatorBooleanInputProcessor(),
+      new SwitchOperatorStringInputProcessor(),
+      new SwitchOperatorNumericalInputProcessor(),
+      new BooleanToStateProcessor(),
+      new NumberLabelerProcessor(),
+      new StringToStateProcessor(),
+      new StringCounterProcessor(),
+      new BooleanOperatorProcessor(),
+      new FiledRenameProcessor(),
+      new MultiFieldRenameRuntime(),
+      new RoundProcessor()
+  );
+}
 
   @Override
   public List<IModelMigrator<?, ?>> migrators() {

--- a/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameDeclarer.java
+++ b/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameDeclarer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.processors.transformation.jvm.processor.fieldrenamermulti;
+
+import org.apache.streampipes.extensions.api.pe.config.IDataProcessorConfiguration;
+import org.apache.streampipes.model.DataProcessorType;
+import org.apache.streampipes.model.extensions.ExtensionAssetType;
+import org.apache.streampipes.sdk.StaticProperties;
+import org.apache.streampipes.sdk.builder.ProcessingElementBuilder;
+import org.apache.streampipes.sdk.builder.StreamRequirementsBuilder;
+import org.apache.streampipes.sdk.builder.processor.DataProcessorConfiguration;
+import org.apache.streampipes.sdk.helpers.Labels;
+import org.apache.streampipes.sdk.helpers.Locales;
+import org.apache.streampipes.sdk.utils.Datatypes;
+
+public class MultiFieldRenameDeclarer {
+
+  public static final String MAPPINGS = "mappings";
+  public static final String OLD_FIELD = "old-field";
+  public static final String NEW_FIELD = "new-field";
+
+  public IDataProcessorConfiguration declareConfig() {
+    return DataProcessorConfiguration.create(
+        MultiFieldRenameRuntime::new,
+        ProcessingElementBuilder.create("org.apache.streampipes.processors.transformation.jvm.multifieldrename", 0)
+            .withAssets(ExtensionAssetType.DOCUMENTATION)
+            .withLocales(Locales.EN)
+            .category(DataProcessorType.TRANSFORM)
+            .requiredStream(StreamRequirementsBuilder.create().build())
+            .requiredCollection(Labels.withId(MAPPINGS),
+                StaticProperties.freeTextProperty(Labels.withId(OLD_FIELD), Datatypes.String),
+                StaticProperties.freeTextProperty(Labels.withId(NEW_FIELD), Datatypes.String)
+            )
+            .build()
+    );
+  }
+}

--- a/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameParameters.java
+++ b/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameParameters.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.processors.transformation.jvm.processor.fieldrenamermulti;
+
+import org.apache.streampipes.extensions.api.pe.param.IDataProcessorParameters;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.List;
+
+public class MultiFieldRenameParameters {
+
+  private final List<Pair<String, String>> mappings;
+
+  public MultiFieldRenameParameters(IDataProcessorParameters params) {
+    var extractor = params.extractor();
+    List<String> oldFields = extractor.singleValueParameterFromCollection(MultiFieldRenameDeclarer.OLD_FIELD, String.class);
+    List<String> newFields = extractor.singleValueParameterFromCollection(MultiFieldRenameDeclarer.NEW_FIELD, String.class);
+    var temp = new java.util.ArrayList<Pair<String, String>>();
+    int size = Math.min(oldFields.size(), newFields.size());
+    for (int i = 0; i < size; i++) {
+      temp.add(Pair.of(oldFields.get(i), newFields.get(i)));
+    }
+    this.mappings = java.util.Collections.unmodifiableList(temp);
+  }
+
+  public List<Pair<String, String>> getMappings() {
+    return mappings;
+  }
+}
+
+
+
+

--- a/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameRuntime.java
+++ b/streampipes-extensions/streampipes-processors-transformation-jvm/src/main/java/org/apache/streampipes/processors/transformation/jvm/processor/fieldrenamermulti/MultiFieldRenameRuntime.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.processors.transformation.jvm.processor.fieldrenamermulti;
+
+import org.apache.streampipes.extensions.api.pe.IStreamPipesDataProcessor;
+import org.apache.streampipes.extensions.api.pe.config.IDataProcessorConfiguration;
+import org.apache.streampipes.extensions.api.pe.context.EventProcessorRuntimeContext;
+import org.apache.streampipes.extensions.api.pe.param.IDataProcessorParameters;
+import org.apache.streampipes.extensions.api.pe.routing.SpOutputCollector;
+import org.apache.streampipes.model.runtime.Event;
+import org.apache.streampipes.model.runtime.field.AbstractField;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public class MultiFieldRenameRuntime implements IStreamPipesDataProcessor {
+
+  private MultiFieldRenameParameters parameters;
+
+  @Override
+  public IDataProcessorConfiguration declareConfig() {
+    return new MultiFieldRenameDeclarer().declareConfig();
+  }
+
+  @Override
+  public void onPipelineStarted(IDataProcessorParameters params,
+                                SpOutputCollector spOutputCollector,
+                                EventProcessorRuntimeContext runtimeContext) {
+    this.parameters = new MultiFieldRenameParameters(params);
+  }
+
+  @Override
+  public void onEvent(Event event, SpOutputCollector spOutputCollector) {
+
+    for (Pair<String, String> mapping : parameters.getMappings()) {
+      AbstractField<?> field = event.getFieldBySelector(mapping.getLeft());
+      if (field != null) {
+        event.removeFieldBySelector(mapping.getLeft());
+        event.addField(mapping.getRight(), field);
+      }
+    }
+
+    spOutputCollector.collect(event);
+  }
+
+  @Override
+  public void onPipelineStopped() {
+    // nothing to clean up
+  }
+}


### PR DESCRIPTION
This PR introduces a new multi-field rename processor that allows renaming
multiple event fields in a single processing step.

Changes included:
- Added MultiFieldRenameDeclarer, Runtime, and Parameters
- Registered processor in TransformationExtensionModuleExport
- Follows existing single-field rename processor patterns

Build verified locally.

