### PR TITLE
fix(ui): persist asset filters across navigation and define explicit context boundaries

### DIFF
--- a/docs/architecture/DOMAIN_PROPERTY_INVENTORY.md
+++ b/docs/architecture/DOMAIN_PROPERTY_INVENTORY.md
@@ -1,0 +1,43 @@
+# Domain Property Inventory
+
+This document lists hard-coded domain properties found in the Apache StreamPipes repository, as part of the analysis for Issue #1373.
+
+## Findings
+
+| File Path | Component | Domain Property String | Context |
+| :--- | :--- | :--- | :--- |
+| `streampipes-sdk/.../helpers/EpRequirements.java` | `EpRequirements` | `http://schema.org/DateTime` | Method `timestampReq()` returns a property with this semantic type. |
+| `geo-jvm/.../BufferPointProcessor.java` | `BufferPointProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `semanticTypeReq` for geometry requirement. |
+| `geo-jvm/.../BufferPointProcessor.java` | `BufferPointProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq` for coordinate system requirement. |
+| `geo-jvm/.../LatLngToJtsPointProcessor.java` | `LatLngToJtsPointProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../LatLngToJtsPointProcessor.java` | `LatLngToJtsPointProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `.semanticType(...)` builder. |
+| `geo-jvm/.../EpsgProcessor.java` | `EpsgProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `.semanticType(...)` builder. |
+| `geo-jvm/.../ReprojectionProcessor.java` | `ReprojectionProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../ReprojectionProcessor.java` | `ReprojectionProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../BufferGeomProcessor.java` | `BufferGeomProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../BufferGeomProcessor.java` | `BufferGeomProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../TopologyValidationProcessor.java` | `TopologyValidationProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../TopologyValidationProcessor.java` | `TopologyValidationProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../GeometryValidationProcessor.java` | `GeometryValidationProcessor` | `http://www.opengis.net/ont/geosparql#Geometry` | Used in `semanticTypeReq`. |
+| `geo-jvm/.../GeometryValidationProcessor.java` | `GeometryValidationProcessor` | `http://data.ign.fr/def/ignf#CartesianCS` | Used in `semanticTypeReq`. |
+| `image-processing-jvm/.../GenericImageClassificationProcessor.java` | `GenericImageClassificationProcessor` | `https://image.com` | Used in `semanticTypeReq` for image input. |
+| `image-processing-jvm/.../GenericImageClassificationProcessor.java` | `GenericImageClassificationProcessor` | `https://schema.org/score` | Used in output property definition. |
+| `image-processing-jvm/.../GenericImageClassificationProcessor.java` | `GenericImageClassificationProcessor` | `https://schema.org/category` | Used in output property definition. |
+| `image-processing-jvm/.../QrCodeReaderProcessor.java` | `QrCodeReaderProcessor` | `https://image.com` | Used in `semanticTypeReq`. |
+| `image-processing-jvm/.../RequiredBoxStream.java` | `RequiredBoxStream` | `https://image.com` | Used in `semanticTypeReq`. |
+
+## Summary of URIs
+
+- **GeoSPARQL**: `http://www.opengis.net/ont/geosparql#Geometry` (7 occurrences)
+- **IGNF**: `http://data.ign.fr/def/ignf#CartesianCS` (7 occurrences)
+- **Schema.org**:
+  - `http://schema.org/DateTime` (1 occurrence in SDK)
+  - `https://schema.org/score` (1 occurrence)
+  - `https://schema.org/category` (1 occurrence)
+- **Custom/Placeholder**: `https://image.com` (3 occurrences)
+
+## Observations
+
+- `EpRequirements.timestampReq` uses a string literal for `http://schema.org/DateTime`. The SDK vocabulary `SO` contains a constant `SO.DATE_TIME`.
+- The `Geo` vocabulary class contains constants for `LAT`, `LNG`, and `ALT`.
+- `https://image.com` is used in image processing components.

--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-toolbar.component.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-toolbar.component.ts
@@ -66,7 +66,6 @@ export class AssetBrowserToolbarComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.assetBrowserService.resetFilters();
         this.assetBrowserData$?.unsubscribe();
     }
 

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
@@ -76,9 +76,10 @@ export class SpAssetOverviewComponent implements OnInit {
         private currentUserService: CurrentUserService,
         private dialog: MatDialog,
         private translateService: TranslateService,
-    ) {}
+    ) { }
 
     ngOnInit(): void {
+        this.assetBrowserService.applyAssetLinkType('');
         this.hasWritePrivilege = this.currentUserService.hasRole(
             UserPrivilege.PRIVILEGE_WRITE_ASSETS,
         );

--- a/ui/src/app/core/components/toolbar/toolbar.component.ts
+++ b/ui/src/app/core/components/toolbar/toolbar.component.ts
@@ -37,8 +37,7 @@ import { SpAssetBrowserService } from '@streampipes/shared-ui';
 })
 export class ToolbarComponent
     extends BaseNavigationComponent
-    implements OnInit, OnDestroy
-{
+    implements OnInit, OnDestroy {
     @ViewChild('feedbackOpen') feedbackOpen: MatMenuTrigger;
     @ViewChild('accountMenuOpen') accountMenuOpen: MatMenuTrigger;
 
@@ -61,7 +60,6 @@ export class ToolbarComponent
     private assetFilterService = inject(SpAssetBrowserService);
 
     ngOnInit(): void {
-        this.assetFilterService.applyAssetLinkType('');
         this.unreadNotificationsSubscription = timer(0, 10000)
             .pipe(exhaustMap(() => this.restApi.getUnreadNotificationsCount()))
             .subscribe(response => {
@@ -132,6 +130,7 @@ export class ToolbarComponent
 
     logout() {
         this.authService.logout();
+        this.assetFilterService.resetFilters();
         this.router.navigate(['login']);
     }
 


### PR DESCRIPTION
# Fix Filter Propagation Between Resources and Assets

## Overview

This pull request fixes an issue where filters applied in one resource view (e.g., Connect) were lost or incorrectly applied when navigating to the Asset View.

The root cause was that filter state was implicitly tied to component lifecycle events (such as `ngOnDestroy`) and global toolbar initialization, leading to unintended resets during navigation.

This change makes filter lifecycle management **explicit, predictable, and context-aware**.

---

## Changes Made

### Asset Browser Toolbar
- Removed `resetFilters()` from `ngOnDestroy`
- Prevents filter state from being cleared when the toolbar component is destroyed during navigation

### Core Toolbar
- Removed `applyAssetLinkType('')` from `ngOnInit`
- Prevents the global toolbar from resetting asset context on every page load
- Context initialization is now handled by the owning view

### Session Handling
- Added `resetFilters()` to `logout()`
- Ensures filter state is cleared when a user session ends
- Prevents stale filters from leaking across sessions

### Asset Overview
- Added `applyAssetLinkType('')` to `ngOnInit`
- Explicitly defines the Asset View context as “All Assets”
- Prevents inheriting restricted contexts (e.g., `adapter`) from previously visited views

---

## Intended Behavior Change

- Filters **persist across navigation** between resource views
- Filters are cleared only when:
  - the user clicks **Reset**, or
  - the user **logs out**
- Context boundaries (such as Asset Overview) explicitly define asset scope

This behavior change is intentional and required for correct filter propagation.

---

## Verification

### Manual Verification

#### Filter Propagation
1. Navigate to **Connect**
2. Apply a filter (Label, Site, etc.)
3. Navigate to **Assets**
4. Filter remains active and the asset list reflects it

#### Context Reset
1. Navigate to **Connect** (context = `adapter`)
2. Navigate to **Assets**
3. Asset View shows all assets (context reset via `applyAssetLinkType('')`)

#### Logout
1. Apply filters
2. Logout and log back in
3. Navigate to **Assets**
4. No filters are active

#### Reset Button
1. Apply filters
2. Click **Reset**
3. Filters are cleared and the view updates

---

## Automated Tests

- Existing Cypress tests under `cypress/tests/assetManagement` pass
- No new tests were added, as this change adjusts UI state lifecycle rather than introducing new logic paths
- Existing regression coverage validates navigation and reset behavior

---

## Notes

- This PR intentionally decouples filter state from component destruction
- Component lifecycle is no longer treated as a state boundary
- Filter lifecycle is now owned by:
  - explicit user actions (Reset)
  - session lifecycle (Logout)
  - context-defining views
