### PR TITLE
fix(#4241): wait for file selection before continuing File_Stream setup

### DIFF
--- a/ui/cypress/support/utils/connect/ConnectBtns.ts
+++ b/ui/cypress/support/utils/connect/ConnectBtns.ts
@@ -148,6 +148,12 @@ export class ConnectBtns {
         return cy.dataCy('adapter-settings-next-button');
     }
 
+    public static fileInputSelected() {
+        return cy.dataCy('file-input-selected', {
+            timeout: 10000,
+        });
+    }
+
     // ========================================================================
 
     // =====================  Event Schema buttons  ==========================

--- a/ui/cypress/support/utils/connect/ConnectUtils.ts
+++ b/ui/cypress/support/utils/connect/ConnectUtils.ts
@@ -194,6 +194,11 @@ export class ConnectUtils {
 
             StaticPropertyUtils.input(adapterInput.formatConfiguration);
         }
+
+        // For file adapters, wait until the file selection state is rendered to reduce test flakiness.
+        if (adapterInput?.adapterType === 'File_Stream') {
+            ConnectBtns.fileInputSelected().should('be.visible');
+        }
     }
 
     public static finishEventSchemaConfiguration() {

--- a/ui/src/app/core-ui/static-properties/static-file-input/static-file-input.component.html
+++ b/ui/src/app/core-ui/static-properties/static-file-input/static-file-input.component.html
@@ -47,6 +47,7 @@
                             matSuffix
                             mat-icon-button
                             [attr.aria-label]="'Clear' | translate"
+                            data-cy="file-input-selected"
                             (click)="selectedFile = {}"
                         >
                             <mat-icon>close</mat-icon>


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

Reduce flakiness in the `File_Stream` Cypress flow by waiting until the UI indicates that a file has been selected before continuing to the next adapter configuration step.

## Problem
Tests using the file stream adapter sometimes continue before the selected file is fully loaded in the UI. In those cases, the next step is opened without a valid file reference and the backend may respond with:

```text
Could not find file: null
```

## Fix

- Add a dedicated `data-cy` marker in the file input component that is only rendered when a file is selected
- Use that marker in Cypress before clicking `Next` for `File_Stream` adapters

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
