### PR TITLE
fix(#4246): Accept full and shorthand propertyScope values in compactadapters

### DIFF
--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/compact/SchemaMetadataEnricher.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/compact/SchemaMetadataEnricher.java
@@ -22,7 +22,6 @@ import org.apache.streampipes.model.connect.adapter.compact.CompactEventProperty
 import org.apache.streampipes.model.schema.EventProperty;
 import org.apache.streampipes.model.schema.EventPropertyPrimitive;
 import org.apache.streampipes.model.schema.PropertyScope;
-import org.apache.streampipes.vocabulary.XSD;
 
 import java.net.URI;
 import java.util.Map;
@@ -68,24 +67,17 @@ public class SchemaMetadataEnricher {
   }
 
   private PropertyScope convertScope(String scope) {
-    if (scope.equalsIgnoreCase("header")) {
-      return PropertyScope.HEADER_PROPERTY;
-    } else if (scope.equalsIgnoreCase("dimension")) {
-      return PropertyScope.DIMENSION_PROPERTY;
-    } else if (scope.equalsIgnoreCase("measurement")) {
+    if (scope == null || scope.isBlank()) {
       return PropertyScope.MEASUREMENT_PROPERTY;
-    } else {
-      return PropertyScope.NONE;
     }
-  }
 
-  private String convertType(String shortRuntimeType) {
-    return switch (shortRuntimeType) {
-      case "integer" -> XSD.INTEGER.toString();
-      case "boolean" -> XSD.BOOLEAN.toString();
-      case "float" -> XSD.FLOAT.toString();
-      case "double" -> XSD.DOUBLE.toString();
-      default -> XSD.STRING.toString();
+    return switch (scope.trim().toUpperCase()) {
+      case "HEADER", "HEADER_PROPERTY" -> PropertyScope.HEADER_PROPERTY;
+      case "DIMENSION", "DIMENSION_PROPERTY" -> PropertyScope.DIMENSION_PROPERTY;
+      case "MEASUREMENT", "MEASUREMENT_PROPERTY" -> PropertyScope.MEASUREMENT_PROPERTY;
+      case "NONE" -> PropertyScope.NONE;
+      default -> PropertyScope.MEASUREMENT_PROPERTY;
     };
   }
+
 }


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

Fixes #4246. The compact adapter API accepted only one representation of `propertyScope`, while the UI’s "View pipeline as code" output used another. This made copied adapter definitions misleading and could cause schema fields to fall back to `NONE`, which in turn prevented expected Data Lake persistence behavior.

This fix makes the compact adapter scope handling backward compatible by accepting both the legacy shorthand values and the full enum-style values. That removes the mismatch between code view output and API input while preserving support for existing clients.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
