### PR TITLE
Feat:Improved dark theme implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   ~ the License.  You may obtain a copy of the License at
   ~
   ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
   ~ the License.  You may obtain a copy of the License at
   ~
   ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and

--- a/ui/deployment/theme/_custom-variables.scss
+++ b/ui/deployment/theme/_custom-variables.scss
@@ -49,6 +49,7 @@
 .dark-mode {
     --color-primary: var(--color-primary-dark);
     --color-secondary: var(--color-secondary-dark);
+    --color-menubar-text-menu-group: #120c47;
     --color-navigation-text: #121212;
     --content-box-color: #404040;
 }

--- a/ui/src/app/chart/components/chart-view/chart-view.component.ts
+++ b/ui/src/app/chart/components/chart-view/chart-view.component.ts
@@ -354,8 +354,10 @@ export class ChartViewComponent
             this.translateService.instant('New chart');
         this.dataView.dataConfig = {};
         this.dataView.dataConfig.ignoreMissingValues = false;
-        this.dataView.baseAppearanceConfig.backgroundColor = '#FFFFFF';
-        this.dataView.baseAppearanceConfig.textColor = '#3e3e3e';
+        this.dataView.baseAppearanceConfig.backgroundColor =
+            'var(--color-bg-0)';
+        this.dataView.baseAppearanceConfig.textColor =
+            'var(--color-default-text)';
         this.dataView.metadata = {
             createdAtEpochMs: Date.now(),
             lastModifiedEpochMs: Date.now(),

--- a/ui/src/app/connect/components/filter-toolbar/filter-toolbar.component.scss
+++ b/ui/src/app/connect/components/filter-toolbar/filter-toolbar.component.scss
@@ -17,7 +17,7 @@
  */
 
 ::ng-deep .mat-select-panel {
-    background: #fff;
+    background: var(--color-bg-0);
 }
 
 ::ng-deep .mat-select-panel:not([class*='mat-elevation-z']) {

--- a/ui/src/app/core-ui/static-properties/static-mapping-unary/static-mapping-unary.component.scss
+++ b/ui/src/app/core-ui/static-properties/static-mapping-unary/static-mapping-unary.component.scss
@@ -25,7 +25,7 @@ form {
 }
 
 ::ng-deep .mat-select-panel {
-    background: #fff;
+    background: var(--color-bg-0);
 }
 
 ::ng-deep .mat-select-panel:not([class*='mat-elevation-z']) {

--- a/ui/src/app/core/components/iconbar/iconbar.component.scss
+++ b/ui/src/app/core/components/iconbar/iconbar.component.scss
@@ -284,5 +284,5 @@
 
 :host-context(.dark-mode) .menu-group-title,
 :host-context(.dark-mode) .chevron {
-    color: #120c47 !important;
+    color: var(--color-menubar-text-menu-group) !important;
 }

--- a/ui/src/app/core/components/iconbar/iconbar.component.scss
+++ b/ui/src/app/core/components/iconbar/iconbar.component.scss
@@ -281,3 +281,8 @@
         --mb-width: 248px;
     }
 }
+
+:host-context(.dark-mode) .menu-group-title,
+:host-context(.dark-mode) .chevron {
+    color: #120c47 !important;
+}

--- a/ui/src/app/core/components/streampipes/streampipes.component.ts
+++ b/ui/src/app/core/components/streampipes/streampipes.component.ts
@@ -62,9 +62,16 @@ export class StreampipesComponent implements OnInit, OnDestroy {
     collapsed = this.collapseService.isCollapsed;
 
     ngOnInit(): void {
-        this.darkMode$ = this.currentUserService.darkMode$.subscribe(
-            dm => (this.darkMode = dm),
-        );
+        this.darkMode$ = this.currentUserService.darkMode$.subscribe(dm => {
+            this.darkMode = dm;
+            if (dm) {
+                document.documentElement.classList.add('dark-mode');
+                document.documentElement.classList.remove('light-mode');
+            } else {
+                document.documentElement.classList.remove('dark-mode');
+                document.documentElement.classList.add('light-mode');
+            }
+        });
         this.user$ = this.currentUserService.user$.subscribe(user => {
             if (user.language !== null && user.language !== 'browser') {
                 this.translate.use(user.language);

--- a/ui/src/app/core/components/toolbar/toolbar.component.ts
+++ b/ui/src/app/core/components/toolbar/toolbar.component.ts
@@ -145,13 +145,18 @@ export class ToolbarComponent
     }
 
     modifyAppearance(darkMode: boolean) {
-        if (darkMode) {
-            this.overlay.getContainerElement().classList.remove('light-mode');
-            this.overlay.getContainerElement().classList.add('dark-mode');
-        } else {
-            this.overlay.getContainerElement().classList.remove('dark-mode');
-            this.overlay.getContainerElement().classList.add('light-mode');
-        }
+        const targets = [
+            document.documentElement,
+            document.body,
+            this.overlay.getContainerElement(),
+        ];
+        const [addClass, removeClass] = darkMode
+            ? ['dark-mode', 'light-mode']
+            : ['light-mode', 'dark-mode'];
+        targets.forEach(el => {
+            el.classList.remove(removeClass);
+            el.classList.add(addClass);
+        });
     }
 
     openDocumentation() {

--- a/ui/src/app/editor/components/pipeline-element-icon-stand/pipeline-element-icon-stand-row/pipeline-element-icon-stand-row.component.scss
+++ b/ui/src/app/editor/components/pipeline-element-icon-stand/pipeline-element-icon-stand-row/pipeline-element-icon-stand-row.component.scss
@@ -39,7 +39,6 @@
     line-height: 70px;
     box-shadow: 1px 1px 2px var(--color-shadow);
     text-align: center;
-    background: white;
     z-index: 100;
 }
 

--- a/ui/src/app/profile/components/general/general-profile-settings.component.html
+++ b/ui/src/app/profile/components/general/general-profile-settings.component.html
@@ -116,16 +116,6 @@
                         >
                     </mat-radio-group>
                 </sp-form-field>
-                <div>
-                    <button
-                        mat-button
-                        mat-flat-button
-                        color="accent"
-                        (click)="updateAppearanceMode()"
-                    >
-                        {{ 'Save color schema' | translate }}
-                    </button>
-                </div>
             </sp-split-section>
         </div>
     }

--- a/ui/src/app/profile/components/general/general-profile-settings.component.ts
+++ b/ui/src/app/profile/components/general/general-profile-settings.component.ts
@@ -110,6 +110,7 @@ export class GeneralProfileSettingsComponent
 
     changeModePreview(value: boolean) {
         this.currentUserService.darkMode$.next(value);
+        this.updateAppearanceMode();
     }
 
     onUserDataReceived() {

--- a/ui/src/scss/sp/main.scss
+++ b/ui/src/scss/sp/main.scss
@@ -135,7 +135,7 @@ md-toolbar:not(.md-menu-toolbar) {
 }
 
 md-content {
-    background: #fff !important;
+    background: var(--color-bg-0) !important;
 }
 
 .page-container {
@@ -214,8 +214,8 @@ md-content {
 }
 
 .wizard-inactive {
-    background-color: white !important;
-    color: black !important;
+    background-color: var(--color-bg-0) !important;
+    color: var(--color-default-text) !important;
     border: 2px solid var(--color-primary) !important;
 }
 
@@ -238,7 +238,7 @@ md-content {
 }
 
 .full-background {
-    background: #fff;
+    background: var(--color-bg-0);
 }
 
 .box-shadow-login {
@@ -275,7 +275,7 @@ md-content {
 }
 
 .tree-node-title {
-    color: black;
+    color: var(--color-default-text);
     padding: 3px;
     font-size: 12px;
 }
@@ -286,10 +286,10 @@ md-content {
 }
 
 .tree-node {
-    border: 1px solid #dae2ea;
+    border: 1px solid var(--color-bg-3);
     border-radius: 5px;
-    background: #ffffff;
-    color: rgb(63, 81, 181);
+    background: var(--color-bg-0);
+    color: var(--color-primary);
     margin: 5px;
 }
 
@@ -515,7 +515,7 @@ md-content {
     box-shadow: 0 0 2px var(--color-primary);
     display: inline-block;
     vertical-align: middle;
-    background-color: white;
+    background-color: var(--color-pe);
     line-height: 150px;
     text-align: center;
     margin-left: auto;
@@ -547,7 +547,7 @@ md-content {
     top: -50px;
     height: 40%;
     width: 40%;
-    background-color: #ffffff;
+    background-color: var(--color-bg-0);
     box-shadow: 0 0 2px #555;
     line-height: 1.6;
     border-radius: 50%;
@@ -563,7 +563,7 @@ md-content {
 
 .recommended-item {
     box-shadow: 0 0 2px #555;
-    background-color: #ffffff;
+    background-color: var(--color-bg-0);
     cursor: pointer;
 }
 

--- a/ui/src/scss/sp/sp-theme.scss
+++ b/ui/src/scss/sp/sp-theme.scss
@@ -34,7 +34,6 @@
 }
 
 html {
-    color-scheme: light;
     @include mat.theme(
         (
             color: mat3theme.$primary-palette,
@@ -43,39 +42,54 @@ html {
             density: -2,
         ),
         $overrides: (
-            primary: light-dark(var(--color-primary), var(--color-primary-dark)),
-            secondary: light-dark(
-                    var(--color-secondary),
-                    var(--color-secondary-dark)
-                ),
-            on-primary: light-dark(#ccc, #fff),
+            primary: var(--color-primary),
+            secondary: var(--color-secondary),
+            on-primary: #ccc,
             primary-container: mat.get-theme-color(
                     mat3theme.$palettes,
                     primary,
                     95
                 ),
-            surface: light-dark(#ffffff, #000000),
-            surface-variant: light-dark(#eaeaea, #2a2a2a),
-            surface-container: light-dark(#f5f5f5, #161616),
-            surface-container-low: light-dark(#fafafa, #121212),
-            surface-container-high: light-dark(#eeeeee, #1c1c1c),
-            surface-container-highest: light-dark(#e0e0e0, #2a2a2a),
-            on-surface: light-dark(#1a1a1a, #dddddd),
-            on-surface-variant: light-dark(#5e5e5e, #b5b5b5),
+            surface: #ffffff,
+            surface-dim: #e0e0e0,
+            surface-bright: #ffffff,
+            surface-variant: #eaeaea,
+            surface-container-lowest: #ffffff,
+            surface-container-low: #fafafa,
+            surface-container: #f5f5f5,
+            surface-container-high: #eeeeee,
+            surface-container-highest: #e0e0e0,
+            on-surface: #1a1a1a,
+            on-surface-variant: #5e5e5e,
             surface-tint: transparent,
-            background: light-dark(#fafafa, #121212)
+            background: #fafafa
         )
     );
 
-    .dark-mode {
-        color-scheme: dark;
+    &.dark-mode {
         @include mat.theme-overrides(
-            $overrides: (
+            (
+                primary: var(--color-primary),
+                secondary: var(--color-secondary),
+                on-primary: #fff,
                 primary-container: mat.get-theme-color(
                         mat3theme.$palettes,
                         primary,
                         20
                     ),
+                surface: #1e1e1e,
+                surface-dim: #121212,
+                surface-bright: #3a3a3a,
+                surface-variant: #2a2a2a,
+                surface-container-lowest: #0f0f0f,
+                surface-container-low: #1a1a1a,
+                surface-container: #1e1e1e,
+                surface-container-high: #282828,
+                surface-container-highest: #333333,
+                on-surface: #e0e0e0,
+                on-surface-variant: #b5b5b5,
+                surface-tint: transparent,
+                background: #121212,
             )
         );
     }


### PR DESCRIPTION
Functionality changes: 
 -removed "save color schema" button in profile for more intuitive handling
 -all chart types (table, pie, heatmap etc.) have default color on initialization (before it was on custom) to produce better visualization

Appearance change to mostly match Angular Material 3 standard (removed the use of manual light-dark() implementation):
 -changed background to dark grey (before black) for better contrast 
 -removed any hardcoded colors that don't respect theme switching
 -exception: hard coded color of the menu-group-title (words "Analytics", "Visualization", "Management"), since they are on a green background and difficult to read with the default color schema

The first and last 3 pictures are the before, all others are the after
<img width="1048" height="534" alt="Screenshot from 2026-03-23 18-42-45" src="https://github.com/user-attachments/assets/3aff2b66-2e4d-4809-946c-5d46be2b322a" />
<img width="1811" height="812" alt="Screenshot from 2026-03-23 18-42-16" src="https://github.com/user-attachments/assets/55049d03-4798-47a7-990a-2043d705d270" />
<img width="1811" height="812" alt="Screenshot from 2026-03-23 18-42-02" src="https://github.com/user-attachments/assets/bd9dedca-c21c-478c-b025-7728f2d70f26" />
<img width="1811" height="812" alt="Screenshot from 2026-03-23 18-41-16" src="https://github.com/user-attachments/assets/8880e5c5-522a-415c-8a65-795183dcc9be" />
<img width="1811" height="812" alt="Screenshot from 2026-03-23 18-41-06" src="https://github.com/user-attachments/assets/0022c1e5-f23c-4867-84a6-36cfd6f58872" />
<img width="305" height="659" alt="Screenshot from 2026-03-23 18-27-52" src="https://github.com/user-attachments/assets/4ae1ded3-1d8a-4c5f-aae1-9c0dcfcfa435" />
<img width="1872" height="708" alt="Screenshot from 2026-03-23 16-58-51" src="https://github.com/user-attachments/assets/b0ffd10b-a12f-40b8-9e7f-66c9d15213ad" />
<img width="1841" height="699" alt="Screenshot from 2026-03-23 16-58-41" src="https://github.com/user-attachments/assets/01cdfcda-14f4-4595-8022-0b4f282f7541" />
<img width="713" height="585" alt="Screenshot from 2026-03-23 16-58-04" src="https://github.com/user-attachments/assets/464134ba-797b-433c-90bd-84b0f60a7174" />

