### PR TITLE
Support timestamp with time zone in PostgreSQL sink

### DIFF
--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypes.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypes.java
@@ -56,7 +56,8 @@ public enum DbDataTypes {
     switch (sqlType.toLowerCase().trim()) {
       case "double precision": return DOUBLE_PRECISION;
       case "character varying": return VAR_CHAR;
-      case "timestamp without time zone": return TIMESTAMP;
+      case "timestamp without time zone":
+      case "timestamp with time zone": return TIMESTAMP;
       case "time without time zone": return TIME;
       default:
         try {

--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypes.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypes.java
@@ -18,6 +18,7 @@
 
 package org.apache.streampipes.sinks.databases.jvm.jdbcclient.model;
 
+import org.apache.streampipes.commons.exceptions.SpRuntimeException;
 
 public enum DbDataTypes {
 
@@ -46,5 +47,23 @@ public enum DbDataTypes {
   @Override
   public String toString() {
     return sqlTerm;
+  }
+
+  public static DbDataTypes fromSqlType(String sqlType) throws SpRuntimeException {
+    if (sqlType == null) {
+      throw new SpRuntimeException("SQL type is null");
+    }
+    switch (sqlType.toLowerCase().trim()) {
+      case "double precision": return DOUBLE_PRECISION;
+      case "character varying": return VAR_CHAR;
+      case "timestamp without time zone": return TIMESTAMP;
+      case "time without time zone": return TIME;
+      default:
+        try {
+          return DbDataTypes.valueOf(sqlType.toUpperCase().trim());
+        } catch (IllegalArgumentException e) {
+          throw new SpRuntimeException("Unsupported SQL type: " + sqlType);
+        }
+    }
   }
 }

--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/TableDescription.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/TableDescription.java
@@ -67,7 +67,7 @@ public class TableDescription {
       if (resultSet.next()) {
         do {
           String columnName = resultSet.getString("COLUMN_NAME");
-          DbDataTypes dataType = DbDataTypes.valueOf(resultSet.getString("DATA_TYPE").toUpperCase());
+          DbDataTypes dataType = DbDataTypes.fromSqlType(resultSet.getString("DATA_TYPE"));
           this.dataTypesHashMap.put(columnName, dataType);
         } while (resultSet.next());
       } else {
@@ -117,16 +117,20 @@ public class TableDescription {
 
   public void validateTable() throws SpRuntimeException {
     for (EventProperty property : this.eventSchema.getEventProperties()) {
-      if (this.getDataTypesHashMap().get(property.getRuntimeName()) != null) {
+      DbDataTypes existingType = this.getDataTypesHashMap().get(property.getRuntimeName());
+      if (existingType != null) {
         if (property instanceof EventPropertyPrimitive) {
-          DbDataTypes dataType = this.getDataTypesHashMap().get(property.getRuntimeName());
-          if (!((EventPropertyPrimitive) property).getRuntimeType()
-              .equals(DbDataTypeFactory.getDataType(dataType).toString())) {
-            throw new SpRuntimeException("Table '" + this.getName() + "' does not match the EventProperties");
+          String expected = ((EventPropertyPrimitive) property).getRuntimeType();
+          String actual = DbDataTypeFactory.getDataType(existingType).toString();
+          if (!expected.equals(actual)) {
+            throw new SpRuntimeException("Column '" + property.getRuntimeName()
+                + "' in table '" + this.getName() + "' has type mismatch: expected "
+                + expected + " but got " + actual);
           }
         }
       } else {
-        throw new SpRuntimeException("Table '" + this.getName() + "' does not match the EventProperties");
+        throw new SpRuntimeException("Column '" + property.getRuntimeName()
+            + "' is missing in table '" + this.getName() + "'");
       }
     }
   }

--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/TableDescription.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/main/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/TableDescription.java
@@ -71,7 +71,7 @@ public class TableDescription {
           this.dataTypesHashMap.put(columnName, dataType);
         } while (resultSet.next());
       } else {
-        throw new SpRuntimeException("Database or Table does nit exist.");
+        throw new SpRuntimeException("Database or Table does not exist.");
       }
     } catch (SQLException e) {
       throw new SpRuntimeException("SqlException: " + e.getMessage() + ", Error code: " + e.getErrorCode()

--- a/streampipes-extensions/streampipes-sinks-databases-jvm/src/test/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypesTest.java
+++ b/streampipes-extensions/streampipes-sinks-databases-jvm/src/test/java/org/apache/streampipes/sinks/databases/jvm/jdbcclient/model/DbDataTypesTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.sinks.databases.jvm.jdbcclient.model;
+
+import org.apache.streampipes.commons.exceptions.SpRuntimeException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DbDataTypesTest {
+
+  @Test
+  public void testFromSqlTypeDoublePrecision() throws SpRuntimeException {
+    assertEquals(DbDataTypes.DOUBLE_PRECISION, DbDataTypes.fromSqlType("double precision"));
+  }
+
+  @Test
+  public void testFromSqlTypeCharacterVarying() throws SpRuntimeException {
+    assertEquals(DbDataTypes.VAR_CHAR, DbDataTypes.fromSqlType("character varying"));
+  }
+
+  @Test
+  public void testFromSqlTypeTimestampWithoutTimeZone() throws SpRuntimeException {
+    assertEquals(DbDataTypes.TIMESTAMP, DbDataTypes.fromSqlType("timestamp without time zone"));
+  }
+
+  @Test
+  public void testFromSqlTypeTimestampWithTimeZone() throws SpRuntimeException {
+    assertEquals(DbDataTypes.TIMESTAMP, DbDataTypes.fromSqlType("timestamp with time zone"));
+  }
+
+  @Test
+  public void testFromSqlTypeTimeWithoutTimeZone() throws SpRuntimeException {
+    assertEquals(DbDataTypes.TIME, DbDataTypes.fromSqlType("time without time zone"));
+  }
+
+  @Test
+  public void testFromSqlTypeBigint() throws SpRuntimeException {
+    assertEquals(DbDataTypes.BIGINT, DbDataTypes.fromSqlType("bigint"));
+  }
+
+  @Test
+  public void testFromSqlTypeInteger() throws SpRuntimeException {
+    assertEquals(DbDataTypes.INTEGER, DbDataTypes.fromSqlType("integer"));
+  }
+
+  @Test
+  public void testFromSqlTypeBoolean() throws SpRuntimeException {
+    assertEquals(DbDataTypes.BOOLEAN, DbDataTypes.fromSqlType("boolean"));
+  }
+
+  @Test
+  public void testFromSqlTypeText() throws SpRuntimeException {
+    assertEquals(DbDataTypes.TEXT, DbDataTypes.fromSqlType("text"));
+  }
+
+  @Test
+  public void testFromSqlTypeReal() throws SpRuntimeException {
+    assertEquals(DbDataTypes.REAL, DbDataTypes.fromSqlType("real"));
+  }
+
+  @Test
+  public void testFromSqlTypeCaseInsensitive() throws SpRuntimeException {
+    assertEquals(DbDataTypes.BIGINT, DbDataTypes.fromSqlType("BIGINT"));
+  }
+
+  @Test
+  public void testFromSqlTypeNull() {
+    assertThrows(SpRuntimeException.class, () -> DbDataTypes.fromSqlType(null));
+  }
+
+  @Test
+  public void testFromSqlTypeUnknown() {
+    assertThrows(SpRuntimeException.class, () -> DbDataTypes.fromSqlType("unknown_type"));
+  }
+}


### PR DESCRIPTION
### Purpose
When you have an existing PostgreSQL table with a "timestamp with time zone" column, the sink can't map the type correctly. It only knew about "timestamp without time zone", so schema detection would break. Updated the type mapping to handle both variants. Also fixed a typo in the error message.

### Remarks
Included tests for the timestamp type mappings to cover both cases.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no