### PR TITLE
fixed csvImportSpec

### DIFF
--- a/ui/cypress/tests/dataset/csvImport.spec.ts
+++ b/ui/cypress/tests/dataset/csvImport.spec.ts
@@ -95,7 +95,6 @@ describe('CSV import happy path', () => {
         DatasetUtils.useExistingDatasetForCsvImport(existingDatasetName);
         DatasetUtils.continueCsvImportToPreview();
         DatasetUtils.selectCsvImportDelimiterComma();
-        DatasetUtils.selectCsvImportTimestampColumn(0);
         DatasetUtils.uploadCsvImport();
         DatasetUtils.expectDatasetTotalEventCount(existingDatasetName, '14');
 
@@ -106,7 +105,6 @@ describe('CSV import happy path', () => {
         DatasetUtils.useExistingDatasetForCsvImport(existingDatasetName);
         DatasetUtils.continueCsvImportToPreview();
         DatasetUtils.selectCsvImportDelimiterComma();
-        DatasetUtils.selectCsvImportTimestampColumn(0);
         DatasetUtils.expectCsvImportSchemaMismatch(
             'Imported columns must exactly match the existing measurement schema.',
             'Timestamp column must be "timestamp" but is "event_time".',


### PR DESCRIPTION
Fix for failing csvImport.spec.ts. 
Setting a timestamp column for already existing datasets is not necessary / available anymore, see  #4394 and #4408.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
