### PR TITLE
4395 Asset filters are not applied to datasets

### DIFF
--- a/ui/src/app/dataset/components/datalake-configuration/datalake-configuration.component.html
+++ b/ui/src/app/dataset/components/datalake-configuration/datalake-configuration.component.html
@@ -60,6 +60,7 @@
                 featureCardId="measurement"
                 [dataSource]="dataSource"
                 [columns]="displayedColumns"
+                [assetContextConfig]="assetContextConfig"
                 [showActionsMenu]="true"
                 matSort
                 data-cy="datalake-settings"

--- a/ui/src/app/dataset/components/datalake-configuration/datalake-configuration.component.ts
+++ b/ui/src/app/dataset/components/datalake-configuration/datalake-configuration.component.ts
@@ -20,6 +20,7 @@ import {
     AfterViewInit,
     Component,
     inject,
+    OnDestroy,
     OnInit,
     ViewChild,
 } from '@angular/core';
@@ -55,11 +56,13 @@ import {
     LocalStorageService,
     ObjectPermissionDialogComponent,
     PanelType,
+    SpAssetBrowserService,
     SpAlertBannerComponent,
     SpBasicHeaderTitleComponent,
     SpBasicViewComponent,
     SpBreadcrumbService,
     SpLabelComponent,
+    SpTableAssetContextConfig,
     SpTableActionsDirective,
     SpTableComponent,
 } from '@streampipes/shared-ui';
@@ -88,6 +91,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { DatePipe, DecimalPipe, NgIf, NgStyle } from '@angular/common';
 import { StyleDirective } from '@ngbracket/ngx-layout/extended';
 import { MatMenuItem } from '@angular/material/menu';
+import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'sp-datalake-configuration',
@@ -131,7 +135,9 @@ import { MatMenuItem } from '@angular/material/menu';
         SpTableActionsDirective,
     ],
 })
-export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
+export class DatalakeConfigurationComponent
+    implements OnInit, AfterViewInit, OnDestroy
+{
     paginator: MatPaginator;
     @ViewChild(MatSort) sort: MatSort;
     @ViewChild(SpTableComponent)
@@ -144,17 +150,24 @@ export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
     private exportProviderRestService = inject(ExportProviderService);
     private translateService = inject(TranslateService);
     private currentUserService = inject(CurrentUserService);
+    private assetFilterService = inject(SpAssetBrowserService);
 
     dataSource: MatTableDataSource<DataLakeConfigurationEntry> =
         new MatTableDataSource([]);
     availableMeasurements: DataLakeConfigurationEntry[] = [];
+    filteredMeasurements: DataLakeConfigurationEntry[] = [];
     availableExportProvider: ExportProviderSettings[] = [];
+    readonly assetContextConfig: SpTableAssetContextConfig = {
+        resourceLinkType: 'measurement',
+        resourceIdKey: 'elementId',
+    };
 
     dataSourceExport: MatTableDataSource<ExportProviderSettings> =
         new MatTableDataSource([]);
 
     displayedColumns: string[] = [
         'name',
+        'assetContext',
         'pipeline',
         'eventsLatest',
         'eventsTotal',
@@ -177,8 +190,16 @@ export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
     pageIndex = 0;
     isAdmin = false;
     writeAccess = false;
+    assetFilter$: Subscription;
+    currentFilterIds: Set<string> = new Set<string>();
 
     ngOnInit(): void {
+        this.assetFilterService.applyAssetLinkType('measurement');
+        this.assetFilter$ =
+            this.assetFilterService.currentAssetFilter$.subscribe(filter => {
+                this.currentFilterIds = filter?.activeElementIds;
+                this.applyMeasurementFilters(this.currentFilterIds);
+            });
         this.breadcrumbService.updateBreadcrumb([
             SpConfigurationRoutes.BASE,
             { label: 'Datasets' },
@@ -201,6 +222,10 @@ export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
             this.pageSize = event.pageSize;
             this.receiveMeasurementSizes(this.pageIndex);
         });
+    }
+
+    ngOnDestroy(): void {
+        this.assetFilter$?.unsubscribe();
     }
 
     loadAvailableExportProvider() {
@@ -251,14 +276,46 @@ export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
                         this.availableMeasurements.sort((a, b) =>
                             a.name.localeCompare(b.name),
                         );
-                        this.receiveMeasurementSizes(this.pageIndex);
-                        this.dataSource.data = this.availableMeasurements;
-                        setTimeout(() => {
-                            this.dataSource.paginator = this.paginator;
-                            this.dataSource.sort = this.sort;
-                        });
+                        this.applyMeasurementFilters(this.currentFilterIds);
                     });
             });
+    }
+
+    applyMeasurementFilters(elementIds: Set<string>) {
+        this.currentFilterIds = elementIds;
+        if (elementIds === undefined) {
+            this.filteredMeasurements = [];
+        } else if (elementIds.size === 0) {
+            this.filteredMeasurements = this.availableMeasurements;
+        } else {
+            this.filteredMeasurements = this.availableMeasurements.filter(
+                measurement => elementIds.has(measurement.elementId),
+            );
+        }
+
+        this.dataSource.data = this.filteredMeasurements;
+        this.updatePaginatorAfterFiltering();
+        this.receiveMeasurementSizes(this.pageIndex);
+
+        setTimeout(() => {
+            this.dataSource.paginator = this.paginator;
+            this.dataSource.sort = this.sort;
+        });
+    }
+
+    updatePaginatorAfterFiltering(): void {
+        if (!this.paginator) {
+            return;
+        }
+
+        const maxPageIndex = Math.max(
+            Math.ceil(this.filteredMeasurements.length / this.pageSize) - 1,
+            0,
+        );
+        if (this.pageIndex > maxPageIndex) {
+            this.pageIndex = maxPageIndex;
+            this.paginator.pageIndex = maxPageIndex;
+        }
     }
 
     createExportProvider(provider: ExportProviderSettings | null) {
@@ -421,7 +478,7 @@ export class DatalakeConfigurationComponent implements OnInit, AfterViewInit {
     receiveMeasurementSizes(pageIndex: number) {
         const start = pageIndex * this.pageSize;
         const end = start + this.pageSize;
-        const measurements = this.availableMeasurements
+        const measurements = this.filteredMeasurements
             .slice(start, end)
             .filter(m => m.eventsLatest === -1)
             .map(m => m.name);


### PR DESCRIPTION
Fixes #4395 . Enables the usage of asset filters for the dataset section.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
