### PR TITLE
fix: Improve file watcher process for circular logs

### DIFF
--- a/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/model/FileGenerationState.java
+++ b/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/model/FileGenerationState.java
@@ -19,40 +19,34 @@
 package org.apache.streampipes.extensions.connectors.filewatcher.model;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
 
-public class FileWatcherCheckpoint implements Serializable {
+public class FileGenerationState implements Serializable {
 
-  private String currentFileName;
-  private long currentSequence;
-  private Map<String, FileGenerationState> generationStates;
+  private FileFingerprint fingerprint;
+  private long lastProcessedRecord;
 
-  public FileWatcherCheckpoint() {
-    this.generationStates = new HashMap<>();
+  public FileGenerationState() {
+    this.lastProcessedRecord = -1L;
   }
 
-  public String getCurrentFileName() {
-    return currentFileName;
+  public FileGenerationState(FileFingerprint fingerprint, long lastProcessedRecord) {
+    this.fingerprint = fingerprint;
+    this.lastProcessedRecord = lastProcessedRecord;
   }
 
-  public void setCurrentFileName(String currentFileName) {
-    this.currentFileName = currentFileName;
+  public FileFingerprint getFingerprint() {
+    return fingerprint;
   }
 
-  public long getCurrentSequence() {
-    return currentSequence;
+  public void setFingerprint(FileFingerprint fingerprint) {
+    this.fingerprint = fingerprint;
   }
 
-  public void setCurrentSequence(long currentSequence) {
-    this.currentSequence = currentSequence;
+  public long getLastProcessedRecord() {
+    return lastProcessedRecord;
   }
 
-  public Map<String, FileGenerationState> getGenerationStates() {
-    return generationStates;
-  }
-
-  public void setGenerationStates(Map<String, FileGenerationState> generationStates) {
-    this.generationStates = generationStates;
+  public void setLastProcessedRecord(long lastProcessedRecord) {
+    this.lastProcessedRecord = lastProcessedRecord;
   }
 }

--- a/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileSetWatcher.java
+++ b/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileSetWatcher.java
@@ -20,6 +20,7 @@ package org.apache.streampipes.extensions.connectors.filewatcher.runtime;
 
 import org.apache.streampipes.extensions.api.connect.IEventCollector;
 import org.apache.streampipes.extensions.connectors.filewatcher.model.FileFingerprint;
+import org.apache.streampipes.extensions.connectors.filewatcher.model.FileGenerationState;
 import org.apache.streampipes.extensions.connectors.filewatcher.model.FileWatcherCheckpoint;
 import org.apache.streampipes.extensions.connectors.filewatcher.model.FileWatcherConfig;
 
@@ -78,12 +79,11 @@ public class FileSetWatcher {
 
     var checkpoint = checkpointStore.load(adapterElementId);
     LOG.debug(
-        "Loaded checkpoint for adapter '{}': currentFile='{}', sequence={}, lastProcessedRecord={}, knownGenerations={}.",
+        "Loaded checkpoint for adapter '{}': currentFile='{}', sequence={}, knownGenerations={}.",
         adapterElementId,
         checkpoint.getCurrentFileName(),
         checkpoint.getCurrentSequence(),
-        checkpoint.getLastProcessedRecord(),
-        checkpoint.getProcessedGenerations().size()
+        checkpoint.getGenerationStates().size()
     );
     processCurrentFile(adapterElementId, collector, checkpoint, files);
     processFollowingFiles(adapterElementId, collector, checkpoint, files);
@@ -93,7 +93,7 @@ public class FileSetWatcher {
                                   IEventCollector collector,
                                   FileWatcherCheckpoint checkpoint,
                                   List<FileSlot> files) throws IOException {
-    if (checkpoint.getCurrentFileName() == null || checkpoint.getCurrentFingerprint() == null) {
+    if (checkpoint.getCurrentFileName() == null || generationState(checkpoint, checkpoint.getCurrentFileName()) == null) {
       LOG.debug("No existing checkpoint state found. Starting from the first available matching file.");
       return;
     }
@@ -116,26 +116,45 @@ public class FileSetWatcher {
   }
 
   private long determineStartRecord(FileSlot currentSlot, FileWatcherCheckpoint checkpoint) {
-    if (fingerprintsEqual(currentSlot.fingerprint(), checkpoint.getCurrentFingerprint())) {
-      LOG.debug("File '{}' fingerprint unchanged. Continuing after record {}.",
-          currentSlot.fileName(), checkpoint.getLastProcessedRecord());
-      return checkpoint.getLastProcessedRecord() + 1;
+    var generationState = generationState(checkpoint, currentSlot.fileName());
+    if (generationState == null) {
+      return 0;
     }
 
-    if (config.singleFileGrowthMode() && isAppendedInPlace(currentSlot.fingerprint(), checkpoint.getCurrentFingerprint())) {
+    var previousFingerprint = generationState.getFingerprint();
+    var previousLastProcessedRecord = generationState.getLastProcessedRecord();
+
+    if (fingerprintsEqual(currentSlot.fingerprint(), previousFingerprint)) {
+      LOG.debug("File '{}' fingerprint unchanged. Continuing after record {}.",
+          currentSlot.fileName(), previousLastProcessedRecord);
+      return previousLastProcessedRecord + 1;
+    }
+
+    if (isAppendedInPlace(currentSlot, previousFingerprint)) {
       LOG.debug("File '{}' grew in place. Continuing after record {}.",
-          currentSlot.fileName(), checkpoint.getLastProcessedRecord());
-      return checkpoint.getLastProcessedRecord() + 1;
+          currentSlot.fileName(), previousLastProcessedRecord);
+      return previousLastProcessedRecord + 1;
     }
 
     LOG.debug("File '{}' fingerprint changed. Restarting from record 0.", currentSlot.fileName());
     return 0;
   }
 
-  private boolean isAppendedInPlace(FileFingerprint currentFingerprint, FileFingerprint previousFingerprint) {
-    return currentFingerprint.getSize() > previousFingerprint.getSize()
-        && (!config.considerLastModified()
-        || currentFingerprint.getLastModified() >= previousFingerprint.getLastModified());
+  private boolean isAppendedInPlace(FileSlot currentSlot, FileFingerprint previousFingerprint) {
+    FileFingerprint currentFingerprint = currentSlot.fingerprint();
+    if (previousFingerprint == null || currentFingerprint.getSize() <= previousFingerprint.getSize()) {
+      return false;
+    }
+    if (config.considerLastModified()
+        && currentFingerprint.getLastModified() < previousFingerprint.getLastModified()) {
+      return false;
+    }
+
+    try {
+      return prefixSha256(currentSlot.path(), previousFingerprint.getSize()).equals(previousFingerprint.getContentHash());
+    } catch (IOException e) {
+      throw new RuntimeException("Could not verify appended content for " + currentSlot.fileName(), e);
+    }
   }
 
   private boolean fingerprintsEqual(FileFingerprint left, FileFingerprint right) {
@@ -164,14 +183,26 @@ public class FileSetWatcher {
     LOG.debug("Processing following files starting at index {}.", startIndex);
     for (int offset = 0; offset < files.size(); offset++) {
       FileSlot candidate = files.get((startIndex + offset) % files.size());
-      FileFingerprint processedFingerprint = checkpoint.getProcessedGenerations().get(candidate.fileName());
-      if (processedFingerprint != null && fingerprintsEqual(processedFingerprint, candidate.fingerprint())) {
-        LOG.debug("Stopping at file '{}' because this generation was already processed.", candidate.fileName());
-        break;
+      if (candidate.fileName().equals(checkpoint.getCurrentFileName())) {
+        continue;
       }
 
-      LOG.debug("Reading new file generation '{}' from record 0.", candidate.fileName());
-      readFile(adapterElementId, collector, checkpoint, candidate, 0);
+      FileGenerationState generationState = generationState(checkpoint, candidate.fileName());
+      FileFingerprint processedFingerprint = generationState == null ? null : generationState.getFingerprint();
+      if (processedFingerprint != null && fingerprintsEqual(processedFingerprint, candidate.fingerprint())) {
+        LOG.debug("Skipping file '{}' because this generation was already processed.", candidate.fileName());
+        continue;
+      }
+
+      long startRecord = 0;
+      if (generationState != null && isAppendedInPlace(candidate, generationState.getFingerprint())) {
+        startRecord = generationState.getLastProcessedRecord() + 1;
+        LOG.debug("Reading appended file generation '{}' from record {}.", candidate.fileName(), startRecord);
+      } else {
+        LOG.debug("Reading new file generation '{}' from record 0.", candidate.fileName());
+      }
+
+      readFile(adapterElementId, collector, checkpoint, candidate, startRecord);
     }
   }
 
@@ -199,9 +230,7 @@ public class FileSetWatcher {
       collector.collect(eventMapper.map(event));
       checkpoint.setCurrentFileName(fileSlot.fileName());
       checkpoint.setCurrentSequence(fileSlot.sequence());
-      checkpoint.setCurrentFingerprint(fileSlot.fingerprint());
-      checkpoint.setLastProcessedRecord(recordIndex);
-      checkpoint.getProcessedGenerations().put(fileSlot.fileName(), fileSlot.fingerprint());
+      checkpoint.getGenerationStates().put(fileSlot.fileName(), new FileGenerationState(fileSlot.fingerprint(), recordIndex));
 
       try {
         checkpointStore.save(adapterElementId, checkpoint);
@@ -215,9 +244,10 @@ public class FileSetWatcher {
 
     checkpoint.setCurrentFileName(fileSlot.fileName());
     checkpoint.setCurrentSequence(fileSlot.sequence());
-    checkpoint.setCurrentFingerprint(fileSlot.fingerprint());
-    checkpoint.setLastProcessedRecord(result.lastProcessedRecord());
-    checkpoint.getProcessedGenerations().put(fileSlot.fileName(), fileSlot.fingerprint());
+    checkpoint.getGenerationStates().put(
+        fileSlot.fileName(),
+        new FileGenerationState(fileSlot.fingerprint(), result.lastProcessedRecord())
+    );
     checkpointStore.save(adapterElementId, checkpoint);
     LOG.debug(
         "Finished file '{}'. Emitted {} events, lastProcessedRecord={}.",
@@ -282,6 +312,10 @@ public class FileSetWatcher {
     return 0;
   }
 
+  private FileGenerationState generationState(FileWatcherCheckpoint checkpoint, String fileName) {
+    return checkpoint.getGenerationStates().get(fileName);
+  }
+
   private FileSlot toFileSlot(Path path) {
     String fileName = path.getFileName().toString();
     return new FileSlot(fileName, path, sequence(fileName), fingerprint(path));
@@ -319,6 +353,28 @@ public class FileSetWatcher {
         int read;
         while ((read = in.read(buffer)) != -1) {
           digest.update(buffer, 0, read);
+        }
+      }
+
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available", e);
+    }
+  }
+
+  private String prefixSha256(Path path, long maxBytes) throws IOException {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      try (InputStream in = Files.newInputStream(path)) {
+        byte[] buffer = new byte[8192];
+        long remaining = maxBytes;
+        while (remaining > 0) {
+          int read = in.read(buffer, 0, (int) Math.min(buffer.length, remaining));
+          if (read == -1) {
+            break;
+          }
+          digest.update(buffer, 0, read);
+          remaining -= read;
         }
       }
 

--- a/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileWatcherCheckpointStore.java
+++ b/streampipes-extensions/streampipes-connectors-filewatcher/src/main/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileWatcherCheckpointStore.java
@@ -56,7 +56,11 @@ public class FileWatcherCheckpointStore {
   }
 
   private Path checkpointPath(String adapterElementId) {
-    return baseDirectory.resolve(adapterElementId + ".json");
+    return baseDirectory.resolve(sanitizeAdapterElementId(adapterElementId) + ".json");
+  }
+
+  private String sanitizeAdapterElementId(String adapterElementId) {
+    return adapterElementId.replace(':', '_');
   }
 
   private static Path resolveDefaultDirectory() {

--- a/streampipes-extensions/streampipes-connectors-filewatcher/src/test/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileSetWatcherTest.java
+++ b/streampipes-extensions/streampipes-connectors-filewatcher/src/test/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileSetWatcherTest.java
@@ -19,6 +19,7 @@
 package org.apache.streampipes.extensions.connectors.filewatcher.runtime;
 
 import org.apache.streampipes.extensions.connectors.filewatcher.model.CsvParserSettings;
+import org.apache.streampipes.extensions.connectors.filewatcher.model.FileGenerationState;
 import org.apache.streampipes.extensions.connectors.filewatcher.model.FileWatcherCheckpoint;
 import org.apache.streampipes.extensions.connectors.filewatcher.model.FileWatcherConfig;
 
@@ -90,9 +91,7 @@ class FileSetWatcherTest {
     FileWatcherCheckpoint checkpoint = new FileWatcherCheckpoint();
     checkpoint.setCurrentFileName(slot.fileName());
     checkpoint.setCurrentSequence(slot.sequence());
-    checkpoint.setCurrentFingerprint(slot.fingerprint());
-    checkpoint.setLastProcessedRecord(1L);
-    checkpoint.getProcessedGenerations().put(slot.fileName(), slot.fingerprint());
+    checkpoint.getGenerationStates().put(slot.fileName(), new org.apache.streampipes.extensions.connectors.filewatcher.model.FileGenerationState(slot.fingerprint(), 1L));
     checkpointStore.save("adapter-2", checkpoint);
 
     List<Map<String, Object>> events = new ArrayList<>();
@@ -197,6 +196,97 @@ class FileSetWatcherTest {
     watcher.poll("adapter-recopy", events::add);
 
     assertEquals(0, events.size());
+  }
+
+  @Test
+  void shouldResumeAppendedSegmentFileWhenLastModifiedIsDisabled() throws IOException, InterruptedException {
+    write("Meldungsarchiv1", "id,value\n1,a\n2,b\n");
+
+    FileSetWatcher watcher = new FileSetWatcher(
+        new FileWatcherConfig(tempDir, Pattern.compile("Meldungsarchiv(\\d+)"), new CsvParserSettings(true, ','), 1, false, false, 0, ZoneId.of("UTC")),
+        new FileWatcherCheckpointStore(tempDir.resolve("checkpoints-append-segment")),
+        new CsvFileReader(),
+        EventMapper.identity()
+    );
+
+    List<Map<String, Object>> events = new ArrayList<>();
+    watcher.poll("adapter-append-segment", events::add);
+
+    assertEquals(2, events.size());
+    events.clear();
+
+    Thread.sleep(5);
+    write("Meldungsarchiv1", "id,value\n1,a\n2,b\n3,c\n");
+    watcher.poll("adapter-append-segment", events::add);
+
+    assertEquals(1, events.size());
+    assertEquals("3", events.get(0).get("id"));
+  }
+
+  @Test
+  void shouldResumeReusedCircularSegmentFromItsOwnCheckpointOffset() throws IOException, InterruptedException {
+    write("Meldungsarchiv0", "id,value\n1,a\n2,b\n");
+    write("Meldungsarchiv3", "id,value\n3,c\n");
+
+    FileSetWatcher watcher = new FileSetWatcher(
+        new FileWatcherConfig(tempDir, Pattern.compile("Meldungsarchiv(\\d+)"), new CsvParserSettings(true, ','), 1, false, false, 0, ZoneId.of("UTC")),
+        new FileWatcherCheckpointStore(tempDir.resolve("checkpoints-circular-reuse")),
+        new CsvFileReader(),
+        EventMapper.identity()
+    );
+
+    List<Map<String, Object>> events = new ArrayList<>();
+    watcher.poll("adapter-circular-reuse", events::add);
+    assertEquals(3, events.size());
+
+    events.clear();
+    Thread.sleep(5);
+    write("Meldungsarchiv0", "id,value\n1,a\n2,b\n4,d\n");
+    watcher.poll("adapter-circular-reuse", events::add);
+
+    assertEquals(1, events.size());
+    assertEquals("4", events.get(0).get("id"));
+  }
+
+  @Test
+  void shouldScanPastUnchangedSegmentToReachWrappedCircularSegment() throws IOException {
+    write("Meldungsarchiv1", "id,value\n1,a\n2,b\n3,c\n");
+    write("Meldungsarchiv2", "id,value\n4,d\n");
+    write("Meldungsarchiv3", "id,value\n5,e\n");
+
+    Path checkpointDir = tempDir.resolve("checkpoints-circular-scan");
+    FileWatcherCheckpointStore checkpointStore = new FileWatcherCheckpointStore(checkpointDir);
+    FileSetWatcher watcher = new FileSetWatcher(
+        new FileWatcherConfig(tempDir, Pattern.compile("Meldungsarchiv(\\d+)"), new CsvParserSettings(true, ','), 1, false, false, 0, ZoneId.of("UTC")),
+        checkpointStore,
+        new CsvFileReader(),
+        EventMapper.identity()
+    );
+
+    List<FileSlot> slots = watcher.discoverFiles();
+    FileWatcherCheckpoint checkpoint = new FileWatcherCheckpoint();
+    for (FileSlot slot : slots) {
+      long lastProcessedRecord = switch ((int) slot.sequence()) {
+        case 1 -> 2L;
+        case 2, 3 -> 0L;
+        default -> throw new IllegalStateException("Unexpected sequence " + slot.sequence());
+      };
+      checkpoint.getGenerationStates().put(
+          slot.fileName(),
+          new FileGenerationState(slot.fingerprint(), lastProcessedRecord)
+      );
+    }
+    checkpoint.setCurrentFileName("Meldungsarchiv2");
+    checkpoint.setCurrentSequence(2);
+    checkpointStore.save("adapter-circular-scan", checkpoint);
+
+    write("Meldungsarchiv1", "id,value\n1,a\n2,b\n3,c\n6,f\n");
+
+    List<Map<String, Object>> events = new ArrayList<>();
+    watcher.poll("adapter-circular-scan", events::add);
+
+    assertEquals(1, events.size());
+    assertEquals("6", events.get(0).get("id"));
   }
 
   private void write(String fileName, String content) throws IOException {

--- a/streampipes-extensions/streampipes-connectors-filewatcher/src/test/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileWatcherCheckpointStoreTest.java
+++ b/streampipes-extensions/streampipes-connectors-filewatcher/src/test/java/org/apache/streampipes/extensions/connectors/filewatcher/runtime/FileWatcherCheckpointStoreTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.extensions.connectors.filewatcher.runtime;
+
+import org.apache.streampipes.extensions.connectors.filewatcher.model.FileFingerprint;
+import org.apache.streampipes.extensions.connectors.filewatcher.model.FileGenerationState;
+import org.apache.streampipes.extensions.connectors.filewatcher.model.FileWatcherCheckpoint;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileWatcherCheckpointStoreTest {
+
+  @TempDir
+  Path tempDir;
+
+  @Test
+  void shouldReplaceColonInCheckpointFileName() throws IOException {
+    FileWatcherCheckpointStore checkpointStore = new FileWatcherCheckpointStore(tempDir);
+    FileWatcherCheckpoint checkpoint = new FileWatcherCheckpoint();
+    checkpoint.setCurrentFileName("Meldungsarchiv1.csv");
+    checkpoint.setCurrentSequence(1);
+    checkpoint.getGenerationStates().put(
+        "Meldungsarchiv1.csv",
+        new FileGenerationState(new FileFingerprint(123L, 456L, "hash"), 7L)
+    );
+
+    checkpointStore.save("adapter:1", checkpoint);
+
+    Path expectedPath = tempDir.resolve("adapter_1.json");
+    assertTrue(Files.exists(expectedPath));
+
+    FileWatcherCheckpoint loadedCheckpoint = checkpointStore.load("adapter:1");
+    assertEquals("Meldungsarchiv1.csv", loadedCheckpoint.getCurrentFileName());
+    assertEquals(1, loadedCheckpoint.getCurrentSequence());
+    assertEquals(1, loadedCheckpoint.getGenerationStates().size());
+    assertEquals(
+        7L,
+        loadedCheckpoint.getGenerationStates().get("Meldungsarchiv1.csv").getLastProcessedRecord()
+    );
+  }
+}


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

This PR tightens the WinCC alarm archive file watcher around circular log handling, checkpointing, and Windows-safe checkpoint filenames.

The watcher now uses per-file generation state as the single checkpoint source of truth, handles reused circular segments without replaying whole files, scans wrapped segment order correctly instead of stopping at the first unchanged file, and stores checkpoint files with : replaced by _ so adapter ids are safe on Windows. 

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no