### PR TITLE
Minor: Eliminate chart name and undo button in toolbar for a consistent workflow

### DIFF
--- a/ui/cypress/support/utils/chart/ChartBtns.ts
+++ b/ui/cypress/support/utils/chart/ChartBtns.ts
@@ -29,6 +29,10 @@ export class ChartBtns {
         return cy.dataCy('sp-manage-save');
     }
 
+    public static manageChartButton(title) {
+        return cy.dataCy('open-manage-permissions-' + title);
+    }
+
     public static saveDashboardBtn() {
         return cy.dataCy('save-dashboard-btn');
     }

--- a/ui/cypress/support/utils/chart/ChartBtns.ts
+++ b/ui/cypress/support/utils/chart/ChartBtns.ts
@@ -148,7 +148,7 @@ export class ChartBtns {
     }
 
     public static discardDataExplorerWidgetBtn() {
-        return cy.dataCy('discard-data-explorer-widget-btn');
+        return cy.dataCy('save-data-explorer-go-back-to-overview');
     }
 
     public static chartDataPreview() {

--- a/ui/cypress/support/utils/chart/ChartUtils.ts
+++ b/ui/cypress/support/utils/chart/ChartUtils.ts
@@ -118,7 +118,6 @@ export class ChartUtils {
     }
 
     public static addDataViewAndWidget(
-        dataViewName: string,
         dataSet: string,
         widgetType: string,
         ignoreTimeSelection = false,
@@ -138,7 +137,6 @@ export class ChartUtils {
         ChartUtils.dataConfigSelectAllFields();
 
         ChartUtils.selectAppearanceConfig();
-        ChartUtils.selectDataViewName(dataViewName);
 
         ChartUtils.openVisualizationConfig();
         ChartUtils.selectVisualizationType(widgetType);
@@ -239,34 +237,22 @@ export class ChartUtils {
     }
 
     public static addDataViewAndTableWidget(
-        dataViewName: string,
         dataSet: string,
         ignoreTimeSelection = false,
     ) {
         this.addDataViewAndWidget(
-            dataViewName,
             dataSet,
             ChartWidget.TABLE,
             ignoreTimeSelection,
         );
     }
 
-    public static addDataViewAndTimeSeriesWidget(
-        dataViewName: string,
-        dataSet: string,
-    ) {
-        this.addDataViewAndWidget(
-            dataViewName,
-            dataSet,
-            ChartWidget.TIME_SERIES,
-        );
+    public static addDataViewAndTimeSeriesWidget(dataSet: string) {
+        this.addDataViewAndWidget(dataSet, ChartWidget.TIME_SERIES);
     }
     public static renameWidget(newName: string) {
-        cy.dataCy('appearance-config-widget-title').clear().type(newName);
-        cy.dataCy('appearance-config-widget-title').should(
-            'have.value',
-            newName,
-        );
+        cy.dataCy('managed-resource-name').clear().type(newName);
+        cy.dataCy('managed-resource-name').should('have.value', newName);
     }
 
     public static renameDashboard(newName: string) {
@@ -343,6 +329,15 @@ export class ChartUtils {
         GeneralUtils.openMenuForRow(dataViewName);
         GeneralUtils.visibleMaterialMenu().within(() => {
             ChartBtns.editDataViewButton(dataViewName).click();
+        });
+    }
+
+    public static manageDataView(dataViewName: string) {
+        // Click edit button
+        // following only works if single view is available
+        GeneralUtils.openMenuForRow(dataViewName);
+        GeneralUtils.visibleMaterialMenu().within(() => {
+            ChartBtns.manageChartButton(dataViewName).click();
         });
     }
 
@@ -455,12 +450,12 @@ export class ChartUtils {
         ChartBtns.startEditWidget(widgetName).click();
     }
 
-    public static saveAndReEditWidget(
-        dataViewName: string,
-        edit: boolean = true,
-    ) {
+    public static saveAndReEditWidget(dataViewName: string) {
         // Save data view configuration
-        ChartUtils.saveDataViewConfiguration(false, edit);
+        ChartBtns.saveDataViewButton().click();
+        cy.dataCy('managed-resource-name').clear().type(dataViewName);
+        ChartBtns.saveDataViewBtn().click();
+        ChartBtns.openNewDataViewBtn().should('be.visible');
         ChartUtils.editDataView(dataViewName);
     }
 
@@ -655,8 +650,10 @@ export class ChartUtils {
         cy.get('div[role=tab]').eq(tabNumber).click();
     }
 
-    public static selectDataViewName(dataViewName: string) {
-        cy.dataCy('appearance-config-widget-title').clear().type(dataViewName);
+    public static selectDataViewNameAndSave(dataViewName: string) {
+        ChartBtns.saveDataViewButton().click();
+        cy.dataCy('managed-resource-name').clear().type(dataViewName);
+        ChartBtns.saveDataViewBtn().click();
     }
 
     public static clickCreateButton() {
@@ -839,14 +836,16 @@ export class ChartUtils {
         ChartUtils.loadDataIntoDataLake('datalake/sample.csv');
 
         // Create Diagram
-        ChartUtils.addDataViewAndTableWidget(
-            'NewWidget',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
         //Save
         ChartBtns.saveDataViewButton().click();
+        ChartUtils.addDataViewName('NewWidget');
         ChartUtils.addDashboardToAsset(assetNames);
         ChartBtns.saveDataViewBtn().click();
         ChartBtns.openNewDataViewBtn().should('be.visible');
+    }
+
+    public static addDataViewName(name) {
+        cy.dataCy('managed-resource-name').clear().type(name);
     }
 }

--- a/ui/cypress/support/utils/chart/ChartUtils.ts
+++ b/ui/cypress/support/utils/chart/ChartUtils.ts
@@ -209,9 +209,9 @@ export class ChartUtils {
     ) {
         ChartUtils.goToDatalake();
 
-        ChartUtils.addDataViewAndTableWidget(dataView, ChartUtils.ADAPTER_NAME);
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.saveDataViewConfiguration(false, false, dataView);
 
         ChartUtils.goToDashboard();
 

--- a/ui/cypress/support/utils/chart/ChartUtils.ts
+++ b/ui/cypress/support/utils/chart/ChartUtils.ts
@@ -344,6 +344,7 @@ export class ChartUtils {
     public static saveDataViewConfiguration(
         confirmSave: boolean = false,
         withoutConfig: boolean = true,
+        name: string = 'New Chart',
     ) {
         if (withoutConfig) {
             ChartBtns.saveDataViewButton().click({
@@ -353,6 +354,7 @@ export class ChartUtils {
             ChartBtns.saveDataViewButton().click({
                 force: true,
             });
+            cy.dataCy('managed-resource-name').clear().type(name);
             ChartBtns.saveDataViewBtn().should('be.visible');
             ChartBtns.saveDataViewBtn().click();
         }
@@ -453,6 +455,13 @@ export class ChartUtils {
     public static saveAndReEditWidget(dataViewName: string) {
         // Save data view configuration
         ChartBtns.saveDataViewButton().click();
+        ChartBtns.openNewDataViewBtn().should('be.visible');
+        ChartUtils.editDataView(dataViewName);
+    }
+
+    public static saveAndEditWidget(dataViewName: string) {
+        // Save data view configuration
+        ChartBtns.saveDataViewButton().click();
         cy.dataCy('managed-resource-name').clear().type(dataViewName);
         ChartBtns.saveDataViewBtn().click();
         ChartBtns.openNewDataViewBtn().should('be.visible');
@@ -546,10 +555,6 @@ export class ChartUtils {
 
         options.forEach(option => {
             cy.dataCy('autocomplete-value-' + option).should('be.visible');
-        });
-
-        cy.dataCy('design-panel-data-settings-filter-value').click({
-            force: true,
         });
     }
 

--- a/ui/cypress/tests/chart/addAssetsToDataView.smoke.spec.ts
+++ b/ui/cypress/tests/chart/addAssetsToDataView.smoke.spec.ts
@@ -57,10 +57,10 @@ describe('Creates a new adapter with a linked asset', () => {
         // Go To Chart and Edit
         ChartUtils.goToDatalake();
         cy.wait(1000);
-        ChartUtils.editDataView('NewWidget');
+        ChartUtils.manageDataView('NewWidget');
         ChartUtils.renameWidget('Rename');
-        ChartUtils.addChartsToAsset([assetName1, assetName3]);
-        ChartBtns.saveDataViewButton().click();
+        ChartUtils.addDashboardToAsset([assetName1, assetName3]);
+        ChartBtns.saveDataViewBtn().click();
         ChartBtns.openNewDataViewBtn().should('be.visible');
 
         AssetUtils.checkAmountOfAssets(3);

--- a/ui/cypress/tests/chart/advancedFilterExpressions.smoke.spec.ts
+++ b/ui/cypress/tests/chart/advancedFilterExpressions.smoke.spec.ts
@@ -64,7 +64,7 @@ describe('Advanced Filter Expressions in Charts', () => {
         // a AND (22 OR 56) => 2 rows in sample.csv
         ChartWidgetTableUtils.checkAmountOfRows(2);
 
-        ChartUtils.saveAndReEditWidget('AdvancedFilterWidget');
+        ChartUtils.saveAndEditWidget('AdvancedFilterWidget');
         ChartWidgetTableUtils.checkAmountOfRows(2);
         ChartUtils.selectDataConfig();
         ChartBtns.advancedFilterBtn().should('be.visible');

--- a/ui/cypress/tests/chart/advancedFilterExpressions.smoke.spec.ts
+++ b/ui/cypress/tests/chart/advancedFilterExpressions.smoke.spec.ts
@@ -27,10 +27,7 @@ describe('Advanced Filter Expressions in Charts', () => {
     });
 
     it('Applies nested advanced filter expressions and persists them', () => {
-        ChartUtils.addDataViewAndTableWidget(
-            'AdvancedFilterWidget',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
         ChartWidgetTableUtils.checkAmountOfRows(10);
         ChartUtils.selectDataConfig();
@@ -67,7 +64,7 @@ describe('Advanced Filter Expressions in Charts', () => {
         // a AND (22 OR 56) => 2 rows in sample.csv
         ChartWidgetTableUtils.checkAmountOfRows(2);
 
-        ChartUtils.saveAndReEditWidget('AdvancedFilterWidget', false);
+        ChartUtils.saveAndReEditWidget('AdvancedFilterWidget');
         ChartWidgetTableUtils.checkAmountOfRows(2);
         ChartUtils.selectDataConfig();
         ChartBtns.advancedFilterBtn().should('be.visible');
@@ -79,10 +76,7 @@ describe('Advanced Filter Expressions in Charts', () => {
     });
 
     it('Closes table filter dropdown with ESC', () => {
-        ChartUtils.addDataViewAndTableWidget(
-            'EscFilterWidget',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
         cy.dataCy('column-filter-trigger-randomtext').click({ force: true });
         cy.get('.column-filter-dropdown').should('be.visible');

--- a/ui/cypress/tests/chart/autoAggregateTable.spec.ts
+++ b/ui/cypress/tests/chart/autoAggregateTable.spec.ts
@@ -48,10 +48,7 @@ describe('Test auto aggregate table result size', () => {
             },
         );
 
-        ChartUtils.addDataViewAndTableWidget(
-            'Auto aggregate table',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
         ChartUtils.selectDataConfig();
         ChartUtils.selectAggregatedQueryType();
         ChartUtils.enableAutoAggregate();

--- a/ui/cypress/tests/chart/chart-types/heatmap.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/heatmap.spec.ts
@@ -26,7 +26,6 @@ describe('Test Heatmap View in Charts', () => {
 
     it('Perform Test', () => {
         ChartUtils.addDataViewAndWidget(
-            'view',
             PrepareTestDataUtils.dataName,
             'heatmap',
         );

--- a/ui/cypress/tests/chart/chart-types/histogram.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/histogram.spec.ts
@@ -26,7 +26,6 @@ describe('Test Histogram View in Charts', () => {
 
     it('Perform Test', () => {
         ChartUtils.addDataViewAndWidget(
-            'view',
             PrepareTestDataUtils.dataName,
             'histogram-chart',
         );

--- a/ui/cypress/tests/chart/chart-types/indicator.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/indicator.spec.ts
@@ -27,7 +27,6 @@ describe('Test Indicator View in Charts', () => {
 
     it('Perform Test', () => {
         ChartUtils.addDataViewAndWidget(
-            'view',
             PrepareTestDataUtils.dataName,
             'indicator-chart',
         );

--- a/ui/cypress/tests/chart/chart-types/map.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/map.spec.ts
@@ -25,11 +25,7 @@ describe('Test Map View in Charts', () => {
     });
 
     it('Perform Test', () => {
-        ChartUtils.addDataViewAndWidget(
-            'view',
-            PrepareTestDataUtils.dataName,
-            'map',
-        );
+        ChartUtils.addDataViewAndWidget(PrepareTestDataUtils.dataName, 'map');
 
         // Change marker positions
         ChartUtils.openVisualizationConfig();

--- a/ui/cypress/tests/chart/chart-types/scatter.smoke.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/scatter.smoke.spec.ts
@@ -26,7 +26,6 @@ describe('Test Scatter View in Charts', () => {
 
     it('Perform Test', () => {
         ChartUtils.addDataViewAndWidget(
-            'view',
             PrepareTestDataUtils.dataName,
             'scatter-chart',
         );

--- a/ui/cypress/tests/chart/chart-types/table.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/table.spec.ts
@@ -28,7 +28,6 @@ describe('Test Table View in Charts', () => {
 
     it('Perform Test', () => {
         ChartUtils.addDataViewAndWidget(
-            'view',
             PrepareTestDataUtils.dataName,
             ChartWidget.TABLE,
         );

--- a/ui/cypress/tests/chart/chart-types/timeSeriesSave.spec.ts
+++ b/ui/cypress/tests/chart/chart-types/timeSeriesSave.spec.ts
@@ -28,18 +28,17 @@ describe('Test if widget configuration is updated correctly', () => {
 
         // Create first test data view with one time series widget
         ChartUtils.addDataViewAndTimeSeriesWidget(
-            testView1,
             PrepareTestDataUtils.dataName,
         );
-        ChartUtils.saveDataViewConfiguration(false, false);
+
+        ChartUtils.saveDataViewConfiguration(false, false, testView1);
 
         cy.wait(1000);
         // Create second test data view with one time series widget
         ChartUtils.addDataViewAndTimeSeriesWidget(
-            testView2,
             PrepareTestDataUtils.dataName,
         );
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.saveDataViewConfiguration(false, false, testView2);
     });
 
     it('Perform Test', () => {

--- a/ui/cypress/tests/chart/chartDataPreview.smoke.spec.ts
+++ b/ui/cypress/tests/chart/chartDataPreview.smoke.spec.ts
@@ -27,7 +27,6 @@ describe('Test Chart Data Preview in Charts', () => {
 
     it('Shows and toggles the chart data preview', () => {
         ChartUtils.addDataViewAndWidget(
-            'preview-view',
             PrepareTestDataUtils.dataName,
             ChartWidget.TIME_SERIES,
         );

--- a/ui/cypress/tests/chart/deleteViewAndDashboard.spec.ts
+++ b/ui/cypress/tests/chart/deleteViewAndDashboard.spec.ts
@@ -29,9 +29,9 @@ describe('Test Deletion of Data View and Dashboard', () => {
 
         ChartUtils.goToDatalake();
 
-        ChartUtils.addDataViewAndTableWidget(dataView, ChartUtils.ADAPTER_NAME);
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.saveDataViewConfiguration(false, false, dataView);
 
         ChartUtils.checkRowsViewsTable(1);
 

--- a/ui/cypress/tests/chart/dynamicColumnFilter.smoke.spec.ts
+++ b/ui/cypress/tests/chart/dynamicColumnFilter.smoke.spec.ts
@@ -27,10 +27,7 @@ describe('Dynamic Column Filters in Table Widget', () => {
     });
 
     it('Applies a Top 10 number filter on a numeric column', () => {
-        ChartUtils.addDataViewAndTableWidget(
-            'DynamicColumnFilterWidget',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
         ChartWidgetTableUtils.checkAmountOfRows(10);
 

--- a/ui/cypress/tests/chart/missingDataInDataLake.spec.ts
+++ b/ui/cypress/tests/chart/missingDataInDataLake.spec.ts
@@ -22,7 +22,6 @@ import { ChartWidgetTableUtils } from '../../support/utils/chart/ChartWidgetTabl
 import { DataLakeSeedUtils } from '../../support/utils/dataset/DataLakeSeedUtils';
 
 describe('Test missing properties in data lake', () => {
-    const dataViewName = 'TestView';
     const headers = ['timestamp', 'v1', 'v2', 'v3', 'v4'];
     const rows = [
         ['1667904471000', '4.1', 'abc', 'true', '1'],
@@ -44,10 +43,7 @@ describe('Test missing properties in data lake', () => {
     });
 
     it('Test table with missing properties', () => {
-        ChartUtils.addDataViewAndTableWidget(
-            dataViewName,
-            PrepareTestDataUtils.dataName,
-        );
+        ChartUtils.addDataViewAndTableWidget(PrepareTestDataUtils.dataName);
 
         ChartWidgetTableUtils.checkAmountOfRows(5);
 

--- a/ui/cypress/tests/chart/timeOrderDataView.spec.ts
+++ b/ui/cypress/tests/chart/timeOrderDataView.spec.ts
@@ -53,8 +53,7 @@ describe('Test Time Order in Charts', () => {
 
         // Save and leave view, edit view again and check ascending order
         ChartUtils.selectAppearanceConfig();
-        ChartUtils.selectDataViewName(chartName);
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.saveDataViewConfiguration(false, false, chartName);
         ChartUtils.editDataView(chartName);
         ChartUtils.clickOrderBy('ascending');
         ChartUtils.openVisualizationConfig();

--- a/ui/cypress/tests/chart/widgetDataConfiguration.smoke.spec.ts
+++ b/ui/cypress/tests/chart/widgetDataConfiguration.smoke.spec.ts
@@ -30,10 +30,7 @@ describe('Test Table View in Charts', () => {
         /**
          * Prepare tests
          */
-        ChartUtils.addDataViewAndTableWidget(
-            'NewWidget',
-            ChartUtils.ADAPTER_NAME,
-        );
+        ChartUtils.addDataViewAndTableWidget(ChartUtils.ADAPTER_NAME);
 
         // Validate that X lines are available
         ChartWidgetTableUtils.checkAmountOfRows(10);
@@ -80,8 +77,11 @@ describe('Test Table View in Charts', () => {
         ChartUtils.checkIfFilterIsSet(1);
         ChartWidgetTableUtils.checkAmountOfRows(4);
         ChartUtils.validateFilterOptions(['=', '!=']);
+
         ChartUtils.validateAutoCompleteOptions(['a', 'b', 'c']);
-        ChartUtils.saveAndReEditWidget('NewWidget', false);
+
+        cy.wait(5000);
+        ChartUtils.saveAndReEditWidget('NewWidget');
         ChartUtils.checkIfFilterIsSet(1);
         ChartWidgetTableUtils.checkAmountOfRows(4);
         ChartUtils.dataConfigRemoveFilter();

--- a/ui/cypress/tests/chart/widgetDataConfiguration.smoke.spec.ts
+++ b/ui/cypress/tests/chart/widgetDataConfiguration.smoke.spec.ts
@@ -79,9 +79,9 @@ describe('Test Table View in Charts', () => {
         ChartUtils.validateFilterOptions(['=', '!=']);
 
         ChartUtils.validateAutoCompleteOptions(['a', 'b', 'c']);
+        cy.dataCy('design-panel-data-settings-filter-value').type('{esc}');
 
-        cy.wait(5000);
-        ChartUtils.saveAndReEditWidget('NewWidget');
+        ChartUtils.saveAndEditWidget('NewWidget');
         ChartUtils.checkIfFilterIsSet(1);
         ChartWidgetTableUtils.checkAmountOfRows(4);
         ChartUtils.dataConfigRemoveFilter();

--- a/ui/cypress/tests/connect/editAdapterDataLakeSchemaUpdate.spec.ts
+++ b/ui/cypress/tests/connect/editAdapterDataLakeSchemaUpdate.spec.ts
@@ -133,8 +133,8 @@ describe('Test adapter updates with data lake schema changes', () => {
     }
 
     function addTableChart(measurementName: string) {
-        ChartUtils.addDataViewAndTableWidget(chartName, measurementName, true);
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.addDataViewAndTableWidget(measurementName, true);
+        ChartUtils.saveDataViewConfiguration(false, false, chartName);
         ChartUtils.checkAmount(1);
     }
 

--- a/ui/cypress/tests/dataDownloadDialog/dataDownloadDialogTest.smoke.spec.ts
+++ b/ui/cypress/tests/dataDownloadDialog/dataDownloadDialogTest.smoke.spec.ts
@@ -29,11 +29,8 @@ describe('Test chart data download dialog', () => {
             'json_array',
         );
 
-        ChartUtils.addDataViewAndTableWidget(
-            dataViewName,
-            PrepareTestDataUtils.dataName,
-        );
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.addDataViewAndTableWidget(PrepareTestDataUtils.dataName);
+        ChartUtils.saveDataViewConfiguration(false, false, dataViewName);
     });
 
     beforeEach('Setup Test', () => {

--- a/ui/cypress/tests/pipeline/pipelineDataLakeSchemaUpdate.spec.ts
+++ b/ui/cypress/tests/pipeline/pipelineDataLakeSchemaUpdate.spec.ts
@@ -169,8 +169,8 @@ describe('Test pipeline updates with data lake schema changes', () => {
     }
 
     function addTableChart(measurementName: string) {
-        ChartUtils.addDataViewAndTableWidget(chartName, measurementName, true);
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.addDataViewAndTableWidget(measurementName, true);
+        ChartUtils.saveDataViewConfiguration(false, false, chartName);
         ChartUtils.checkAmount(1);
     }
 

--- a/ui/cypress/tests/userManagement/testUserRoleCharts.spec.ts
+++ b/ui/cypress/tests/userManagement/testUserRoleCharts.spec.ts
@@ -118,8 +118,8 @@ describe('Test User Roles for Charts', () => {
     function setup() {
         UserUtils.switchUser(chartAdmin1);
         ConnectUtils.addMachineDataSimulator('simulator', true);
-        ChartUtils.addDataViewAndTableWidget(chartName, 'simulator', true);
-        ChartUtils.saveDataViewConfiguration(false, false);
+        ChartUtils.addDataViewAndTableWidget('simulator', true);
+        ChartUtils.saveDataViewConfiguration(false, false, chartName);
         ChartUtils.checkAmount(1);
         ChartUtils.goToDatalake();
     }

--- a/ui/cypress/tests/userManagement/testUserRoleDashboard.spec.ts
+++ b/ui/cypress/tests/userManagement/testUserRoleDashboard.spec.ts
@@ -200,7 +200,7 @@ describe('Test User Roles for Dashboards', () => {
     }
 
     function addChart(chartName: string, saveConfig: boolean = true) {
-        ChartUtils.addDataViewAndTableWidget(chartName, datasetName, true);
-        ChartUtils.saveDataViewConfiguration(false, saveConfig);
+        ChartUtils.addDataViewAndTableWidget(datasetName, true);
+        ChartUtils.saveDataViewConfiguration(false, saveConfig, chartName);
     }
 });

--- a/ui/cypress/tests/userManagement/testUserRoleDataset.spec.ts
+++ b/ui/cypress/tests/userManagement/testUserRoleDataset.spec.ts
@@ -175,8 +175,8 @@ describe('Test Dataset Permissions', () => {
             cy.dataCy('data-explorer-select-data-set').click();
             cy.get('mat-option').contains(datasetName).click();
             ChartBtns.discardDataExplorerWidgetBtn().click();
-            ChartUtils.addDataViewAndTableWidget('test', datasetName, true);
-            ChartUtils.saveDataViewConfiguration(false, false);
+            ChartUtils.addDataViewAndTableWidget(datasetName, true);
+            ChartUtils.saveDataViewConfiguration(false, false, 'test');
         }
     }
 

--- a/ui/src/app/chart/components/chart-view/toolbar/chart-view-toolbar.component.html
+++ b/ui/src/app/chart/components/chart-view/toolbar/chart-view-toolbar.component.html
@@ -25,41 +25,6 @@
             fxLayoutGap="10px"
             fxFlex="100"
         >
-            <div
-                fxFlex="25"
-                fxLayout="row"
-                fxLayoutAlign="start center"
-                class="widget-header-text mr-15"
-            >
-                @if (editMode) {
-                    <div
-                        fxFlex="100"
-                        fxLayout="row"
-                        fxLayoutAlign="start center"
-                        class="form-field-small widget-title-container"
-                    >
-                        <span class="widget-title-text">{{
-                            'Chart Name' | translate
-                        }}</span>
-                        <mat-form-field
-                            appearance="outline"
-                            color="accent"
-                            fxFlex="100"
-                            subscriptSizing="dynamic"
-                        >
-                            <input
-                                data-cy="appearance-config-widget-title"
-                                matInput
-                                [(ngModel)]="
-                                    configuredWidget.baseAppearanceConfig
-                                        .widgetTitle
-                                "
-                            />
-                        </mat-form-field>
-                    </div>
-                }
-            </div>
-
             @if (editMode) {
                 <button
                     mat-flat-button
@@ -70,18 +35,6 @@
                 >
                     <mat-icon>save</mat-icon>
                     {{ (createMode ? 'Create' : 'Save') | translate }}
-                </button>
-            }
-            @if (editMode) {
-                <button
-                    mat-flat-button
-                    [matTooltip]="'Discard' | translate"
-                    class="mat-basic mr-10 edit-menu-btn"
-                    (click)="discardDataViewEmitter.emit()"
-                    data-cy="discard-data-explorer-widget-btn"
-                >
-                    <i class="material-icons">undo</i>
-                    <span>&nbsp;{{ 'Discard' | translate }}</span>
                 </button>
             }
             @if (editMode) {

--- a/ui/src/app/chart/components/chart-view/toolbar/chart-view-toolbar.component.ts
+++ b/ui/src/app/chart/components/chart-view/toolbar/chart-view-toolbar.component.ts
@@ -40,8 +40,6 @@ import {
     LayoutDirective,
     LayoutGapDirective,
 } from '@ngbracket/ngx-layout/flex';
-import { MatFormField } from '@angular/material/form-field';
-import { MatInput } from '@angular/material/input';
 import { FormsModule } from '@angular/forms';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -58,8 +56,6 @@ import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
         FlexDirective,
         LayoutAlignDirective,
         LayoutGapDirective,
-        MatFormField,
-        MatInput,
         FormsModule,
         MatButton,
         MatTooltip,


### PR DESCRIPTION
Eliminate chart name and undo button in toolbar for a consistent workflow.
<img width="846" height="66" alt="image" src="https://github.com/user-attachments/assets/d6bbf574-2c49-4167-a8ea-6815778779b3" />

