### PR TITLE
fix: Split chart request refresh strategies

### DIFF
--- a/ui/src/app/chart-shared/components/charts/base/base-data-explorer-widget.directive.ts
+++ b/ui/src/app/chart-shared/components/charts/base/base-data-explorer-widget.directive.ts
@@ -44,7 +44,7 @@ import {
 } from '../../../models/dataview-dashboard.model';
 import { EMPTY, Observable, Subject, Subscription, zip } from 'rxjs';
 import { ChartFieldProviderService } from '../../../services/chart-field-provider.service';
-import { catchError, exhaustMap, finalize } from 'rxjs/operators';
+import { catchError, exhaustMap, finalize, switchMap } from 'rxjs/operators';
 import { ChartRegistry } from '../../../registry/chart-registry.service';
 import { SpFieldUpdateService } from '../../../services/field-update.service';
 import {
@@ -120,10 +120,14 @@ export abstract class BaseDataExplorerWidgetDirective<
     timeSelection$: Subscription;
     nameChange$: Subscription;
 
-    requestQueue$: Subject<Observable<SpQueryResult>[]> = new Subject<
+    viewModeRequestQueue$: Subject<Observable<SpQueryResult>[]> = new Subject<
         Observable<SpQueryResult>[]
     >();
-    requestInProgress = false;
+    latestRequestQueue$: Subject<Observable<SpQueryResult>[]> = new Subject<
+        Observable<SpQueryResult>[]
+    >();
+    requestQueueSubscriptions = new Subscription();
+    viewModeRequestInProgress = false;
 
     protected widgetConfigurationService = inject(ChartConfigurationService);
     protected resizeService = inject(ResizeService);
@@ -141,33 +145,7 @@ export abstract class BaseDataExplorerWidgetDirective<
         this.fieldProvider =
             this.fieldService.generateFieldLists(sourceConfigs);
 
-        this.requestQueue$
-            .pipe(
-                exhaustMap(observables => {
-                    this.requestInProgress = true;
-                    this.errorCallback.emit(undefined);
-                    return zip(...observables).pipe(
-                        catchError(err => {
-                            this.timerCallback.emit(false);
-                            this.errorCallback.emit(err.error);
-                            this.dataReceivedCallback.emit([]);
-                            return EMPTY;
-                        }),
-                        finalize(() => {
-                            this.requestInProgress = false;
-                        }),
-                    );
-                }),
-            )
-            .subscribe(results => {
-                results.forEach(
-                    (result, index) => (result.sourceIndex = index),
-                );
-                this.timerCallback.emit(false);
-                setTimeout(() => {
-                    this.validateReceivedData(results);
-                });
-            });
+        this.initializeRequestQueues();
 
         this.widgetConfiguration$ =
             this.widgetConfigurationService.configurationChangedSubject.subscribe(
@@ -243,7 +221,9 @@ export abstract class BaseDataExplorerWidgetDirective<
         this.resize$?.unsubscribe();
         this.timeSelection$.unsubscribe();
         this.nameChange$.unsubscribe();
-        this.requestQueue$?.unsubscribe();
+        this.requestQueueSubscriptions.unsubscribe();
+        this.viewModeRequestQueue$?.unsubscribe();
+        this.latestRequestQueue$?.unsubscribe();
     }
 
     public setShownComponents(
@@ -259,7 +239,10 @@ export abstract class BaseDataExplorerWidgetDirective<
     }
 
     public updateData(includeTooMuchEventsParameter: boolean = true) {
-        if (this.requestInProgress) {
+        if (
+            !this.shouldUseLatestRequestStrategy() &&
+            this.viewModeRequestInProgress
+        ) {
             return;
         }
         this.beforeDataFetched();
@@ -267,10 +250,18 @@ export abstract class BaseDataExplorerWidgetDirective<
     }
 
     private loadData(includeTooMuchEventsParameter: boolean) {
+        const observables = this.makeDataRequest(includeTooMuchEventsParameter);
+        this.timerCallback.emit(true);
+        this.getRequestQueue().next(observables);
+    }
+
+    private makeDataRequest(
+        includeTooMuchEventsParameter: boolean,
+    ): Observable<SpQueryResult>[] {
         const returnCompleteResult =
             includeTooMuchEventsParameter &&
             !this.dataExplorerWidget.dataConfig.ignoreTooMuchDataWarning;
-        const observables = this.observableGenerator.generateObservables(
+        return this.observableGenerator.generateObservables(
             this.timeSettings.startTime,
             this.timeSettings.endTime,
             this.dataExplorerWidget.dataConfig as DataExplorerDataConfig,
@@ -279,8 +270,69 @@ export abstract class BaseDataExplorerWidgetDirective<
                 ? BaseDataExplorerWidgetDirective.TOO_MUCH_DATA_PARAMETER
                 : undefined,
         );
-        this.timerCallback.emit(true);
-        this.requestQueue$.next(observables);
+    }
+
+    private getRequestQueue(): Subject<Observable<SpQueryResult>[]> {
+        return this.shouldUseLatestRequestStrategy()
+            ? this.latestRequestQueue$
+            : this.viewModeRequestQueue$;
+    }
+
+    private shouldUseLatestRequestStrategy(): boolean {
+        return this.dataViewMode && this.editMode;
+    }
+
+    private initializeRequestQueues(): void {
+        this.requestQueueSubscriptions.add(
+            this.viewModeRequestQueue$
+                .pipe(
+                    exhaustMap(observables =>
+                        this.executeDataRequest(observables, true),
+                    ),
+                )
+                .subscribe(results => this.handleDataRequestResult(results)),
+        );
+
+        this.requestQueueSubscriptions.add(
+            this.latestRequestQueue$
+                .pipe(
+                    switchMap(observables =>
+                        this.executeDataRequest(observables, false),
+                    ),
+                )
+                .subscribe(results => this.handleDataRequestResult(results)),
+        );
+    }
+
+    private executeDataRequest(
+        observables: Observable<SpQueryResult>[],
+        trackViewModeRequest: boolean,
+    ): Observable<SpQueryResult[]> {
+        if (trackViewModeRequest) {
+            this.viewModeRequestInProgress = true;
+        }
+        this.errorCallback.emit(undefined);
+        return zip(...observables).pipe(
+            catchError(err => {
+                this.timerCallback.emit(false);
+                this.errorCallback.emit(err.error);
+                this.dataReceivedCallback.emit([]);
+                return EMPTY;
+            }),
+            finalize(() => {
+                if (trackViewModeRequest) {
+                    this.viewModeRequestInProgress = false;
+                }
+            }),
+        );
+    }
+
+    private handleDataRequestResult(results: SpQueryResult[]): void {
+        results.forEach((result, index) => (result.sourceIndex = index));
+        this.timerCallback.emit(false);
+        setTimeout(() => {
+            this.validateReceivedData(results);
+        });
     }
 
     validateReceivedData(spQueryResults: SpQueryResult[]) {


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

This PR separates chart data refresh handling by usage context.

In dashboard, kiosk, and normal view mode, widget requests continue to use `exhaustMap`. This keeps the existing protection for high-frequency auto-refresh: if a request is still running, new refresh ticks are ignored instead of piling up.

In the chart/data-view editor, refreshes now use `switchMap`. This gives edit mode “latest change wins” behavior, so changing fields, filters, aggregation, or auto-aggregate cancels stale in-flight requests and executes the newest query.

This fixes cases where edit-mode configuration changes could be dropped while preserving the non-overlapping request behavior needed for dashboard and kiosk auto-refresh.

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
