### PR TITLE
fix: consistent spacing in translation files

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -25,7 +25,7 @@
     "test-cypress-smoke": "npx cypress run --spec 'cypress/tests/**/*.smoke.spec.ts' --config baseUrl=http://localhost:8082",
     "test-cypress-all": "npx cypress run --spec 'cypress/tests/**/*.spec.ts' --config baseUrl=http://localhost:8082",
     "prepare": "cd ../ && husky install ./ui/.husky",
-    "i18n:extract": "ngx-translate-extract --input ./src --input ./projects --output ./deployment/i18n/{en,de,pl}.json -n -s --clean --format json",
+    "i18n:extract": "ngx-translate-extract --input ./src --input ./projects --output ./deployment/i18n/{en,de,pl}.json -n -s --clean --format json --format-indentation '  '",
     "i18n:translate": "node ./deployment/i18n-translate.js",
     "i18n:validate": "node ./deployment/i18n-validate.js",
     "i18n:check": "npm run i18n:extract && prettier --write ./deployment/i18n/{en,de,pl}.json && npm run i18n:validate"


### PR DESCRIPTION
For consistent spacing in the translation files (2 spaces, no tabs ) - added `--format-indentation '  '`.v
