### PR TITLE
fix: Improve asset creation and editing workflow

### DIFF
--- a/ui/cypress/support/utils/asset/AssetUtils.ts
+++ b/ui/cypress/support/utils/asset/AssetUtils.ts
@@ -89,7 +89,6 @@ export class AssetUtils {
         AssetUtils.addNewAsset(asset);
 
         AssetBtns.saveAssetBtn().click();
-        AssetBtns.createBtn().click();
 
         AssetBtns.createAssetBtn().should('be.visible');
     }
@@ -266,7 +265,6 @@ export class AssetUtils {
 
         AssetUtils.checkAmountOfLinkedResources(2);
         AssetBtns.saveAssetBtn().click();
-        AssetBtns.createBtn().click();
         cy.location('hash', { timeout: 10000 }).should(
             'include',
             '/assets/overview',

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
@@ -21,34 +21,36 @@
         [level]="2"
         [title]="('Basics' | translate) + ': ' + asset.assetName"
     >
-        <sp-form-field
-            [level]="2"
-            [label]="'Name' | translate"
-            [description]="'A short name of the asset' | translate"
-        >
-            <mat-form-field>
-                <input
-                    data-cy="asset-name"
-                    matInput
-                    [(ngModel)]="asset.assetName"
-                    [disabled]="!editMode || (rootNode && !isNewAsset)"
-                />
-            </mat-form-field>
-        </sp-form-field>
-        <sp-form-field
-            fxFlex="100"
-            [level]="2"
-            [label]="'Description' | translate"
-            [description]="'A longer description of this asset' | translate"
-        >
-            <mat-form-field>
-                <input
-                    matInput
-                    [(ngModel)]="asset.assetDescription"
-                    [disabled]="!editMode || (rootNode && !isNewAsset)"
-                />
-            </mat-form-field>
-        </sp-form-field>
+        @if (!rootNode || isNewAsset) {
+            <sp-form-field
+                [level]="2"
+                [label]="'Name' | translate"
+                [description]="'A short name of the asset' | translate"
+            >
+                <mat-form-field>
+                    <input
+                        data-cy="asset-name"
+                        matInput
+                        [(ngModel)]="asset.assetName"
+                        [disabled]="!editMode"
+                    />
+                </mat-form-field>
+            </sp-form-field>
+            <sp-form-field
+                fxFlex="100"
+                [level]="2"
+                [label]="'Description' | translate"
+                [description]="'A longer description of this asset' | translate"
+            >
+                <mat-form-field>
+                    <input
+                        matInput
+                        [(ngModel)]="asset.assetDescription"
+                        [disabled]="!editMode"
+                    />
+                </mat-form-field>
+            </sp-form-field>
+        }
         <sp-form-field
             fxFlex="100"
             [level]="2"

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
@@ -22,6 +22,34 @@
         [title]="('Basics' | translate) + ': ' + asset.assetName"
     >
         <sp-form-field
+            [level]="2"
+            [label]="'Name' | translate"
+            [description]="'A short name of the asset' | translate"
+        >
+            <mat-form-field>
+                <input
+                    data-cy="asset-name"
+                    matInput
+                    [(ngModel)]="asset.assetName"
+                    [disabled]="!editMode || (rootNode && !isNewAsset)"
+                />
+            </mat-form-field>
+        </sp-form-field>
+        <sp-form-field
+            fxFlex="100"
+            [level]="2"
+            [label]="'Description' | translate"
+            [description]="'A longer description of this asset' | translate"
+        >
+            <mat-form-field>
+                <input
+                    matInput
+                    [(ngModel)]="asset.assetDescription"
+                    [disabled]="!editMode || (rootNode && !isNewAsset)"
+                />
+            </mat-form-field>
+        </sp-form-field>
+        <sp-form-field
             fxFlex="100"
             [level]="2"
             label="Asset ID"

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.html
@@ -22,34 +22,6 @@
         [title]="('Basics' | translate) + ': ' + asset.assetName"
     >
         <sp-form-field
-            [level]="2"
-            [label]="'Name' | translate"
-            [description]="'A short name of the asset' | translate"
-        >
-            <mat-form-field>
-                <input
-                    data-cy="asset-name"
-                    matInput
-                    [(ngModel)]="asset.assetName"
-                    [disabled]="!editMode"
-                />
-            </mat-form-field>
-        </sp-form-field>
-        <sp-form-field
-            fxFlex="100"
-            [level]="2"
-            [label]="'Description' | translate"
-            [description]="'A longer description of this asset' | translate"
-        >
-            <mat-form-field>
-                <input
-                    matInput
-                    [(ngModel)]="asset.assetDescription"
-                    [disabled]="!editMode"
-                />
-            </mat-form-field>
-        </sp-form-field>
-        <sp-form-field
             fxFlex="100"
             [level]="2"
             label="Asset ID"

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-basics/asset-details-basics.component.ts
@@ -81,6 +81,9 @@ export class AssetDetailsBasicsComponent implements OnInit, OnChanges {
     editMode: boolean;
 
     @Input()
+    isNewAsset: boolean;
+
+    @Input()
     rootNode: boolean;
 
     @Input()

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
@@ -89,6 +89,7 @@
                         [sites]="sites"
                         [rootNode]="rootNode"
                         [editMode]="true"
+                        [isNewAsset]="isNewAsset"
                     >
                     </sp-asset-details-basics>
                 </div>

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
@@ -55,34 +55,36 @@
                         </button>
                     </div>
                 </div>
-                <div fxFlex fxLayout="row" fxLayoutAlign="end center">
-                    <button
-                        mat-icon-button
-                        [matMenuTriggerFor]="optMenu"
-                        [attr.aria-label]="'Options' | translate"
-                        data-cy="options-asset"
-                    >
-                        <mat-icon>more_vert</mat-icon>
-                    </button>
-                    <mat-menu #optMenu="matMenu">
+                @if (!isNewAsset) {
+                    <div fxFlex fxLayout="row" fxLayoutAlign="end center">
                         <button
-                            mat-menu-item
-                            (click)="manageAsset()"
-                            data-cy="manage-asset-btn"
+                            mat-icon-button
+                            [matMenuTriggerFor]="optMenu"
+                            [attr.aria-label]="'Options' | translate"
+                            data-cy="options-asset"
                         >
-                            <mat-icon>settings</mat-icon>
-                            <span>{{ 'Manage' | translate }}</span>
+                            <mat-icon>more_vert</mat-icon>
                         </button>
-                        <button
-                            mat-menu-item
-                            (click)="deleteAsset()"
-                            data-cy="delete-asset-btn"
-                        >
-                            <mat-icon>clear</mat-icon>
-                            <span>{{ 'Delete' | translate }}</span>
-                        </button>
-                    </mat-menu>
-                </div>
+                        <mat-menu #optMenu="matMenu">
+                            <button
+                                mat-menu-item
+                                (click)="manageAsset()"
+                                data-cy="manage-asset-btn"
+                            >
+                                <mat-icon>settings</mat-icon>
+                                <span>{{ 'Manage' | translate }}</span>
+                            </button>
+                            <button
+                                mat-menu-item
+                                (click)="deleteAsset()"
+                                data-cy="delete-asset-btn"
+                            >
+                                <mat-icon>clear</mat-icon>
+                                <span>{{ 'Delete' | translate }}</span>
+                            </button>
+                        </mat-menu>
+                    </div>
+                }
             </div>
             @if (asset) {
                 <div fxFlex="100" fxLayout="column" class="p-10">

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
@@ -45,13 +45,7 @@
                             (click)="saveAsset()"
                         >
                             <i class="material-icons">save</i
-                            ><span
-                                >&nbsp;{{
-                                    isNewAsset
-                                        ? ('Create' | translate)
-                                        : ('Save' | translate)
-                                }}</span
-                            >
+                            ><span>&nbsp;{{ 'Save' | translate }}</span>
                         </button>
                     </div>
                 </div>

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
@@ -93,10 +93,6 @@ export class SpAssetDetailsComponent
     private originalAsset: SpAssetModel;
 
     async saveAsset() {
-        if (this.isNewAsset && this.pendingManageAssetResult === undefined) {
-            this.openManageAssetDialog(true);
-            return;
-        }
         await this.saveAssetChanges();
         this.assetBrowserService.refreshBrowserAssetData();
         this.router.navigate(['assets'], {


### PR DESCRIPTION
# Create 

<img width="1243" height="778" alt="image" src="https://github.com/user-attachments/assets/217a1d78-bfa2-4d7d-b3a7-b608df271b82" />

- Removed three buttons in create Mode 
- Renamed Create to save in create mode 
- removed Create Dialog


# Edit 

<img width="1503" height="808" alt="image" src="https://github.com/user-attachments/assets/92c89c79-6cad-4a32-a50f-838ae0b4735b" />

- does not show name and description for root asset
- three dots with manage mode 

# Asset Management 
- Name and description can only be changed via manage