### PR TITLE
fix: Confirm changes dialog is shown twice when navigating from asset edit mode to another page

### DIFF
--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
@@ -51,7 +51,7 @@ import {
 } from '@streampipes/platform-services';
 import { MatDialog } from '@angular/material/dialog';
 import { firstValueFrom, from, Observable, of } from 'rxjs';
-import { map, switchMap, tap } from 'rxjs/operators';
+import { finalize, map, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { SupportsUnsavedChangeDialog } from '../../../../chart-shared/models/dataview-dashboard.model';
 
 type ManageableAsset = SpAssetModel & {
@@ -93,6 +93,7 @@ export class SpAssetDetailsComponent
     private originalAsset: SpAssetModel;
     private initialGeneratedAssetId?: string;
     private initialGeneratedElementId?: string;
+    private pendingConfirmLeaveDialog?: Observable<boolean>;
 
     async saveAsset() {
         if (this.isNewAsset && this.pendingManageAssetResult === undefined) {
@@ -225,38 +226,42 @@ export class SpAssetDetailsComponent
         _route: ActivatedRouteSnapshot,
         _state: RouterStateSnapshot,
     ): Observable<boolean> {
-        if (this.setShouldShowConfirm()) {
-            const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-                width: '500px',
-                data: {
-                    title: this.translateService.instant('Save changes?'),
-                    subtitle: this.translateService.instant(
-                        'Update all changes to asset or discard current changes.',
-                    ),
-                    neutralTitle: this.translateService.instant('Keep editing'),
-                    cancelTitle:
-                        this.translateService.instant('Discard changes'),
-                    confirmTitle: this.translateService.instant('Update'),
-                },
-            });
-            return dialogRef.afterClosed().pipe(
-                switchMap((dialogResult: ConfirmDialogAction | undefined) => {
-                    if (dialogResult === 'confirm') {
-                        return from(this.saveAssetChanges()).pipe(
-                            map(() => true),
-                        );
-                    }
-
-                    if (dialogResult === 'cancel') {
-                        return of(true);
-                    }
-
-                    return of(false);
-                }),
-            );
-        } else {
+        if (!this.setShouldShowConfirm()) {
             return of(true);
         }
+
+        if (this.pendingConfirmLeaveDialog) {
+            return this.pendingConfirmLeaveDialog;
+        }
+
+        const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+            width: '500px',
+            data: {
+                title: this.translateService.instant('Save changes?'),
+                subtitle: this.translateService.instant(
+                    'Update all changes to asset or discard current changes.',
+                ),
+                neutralTitle: this.translateService.instant('Keep editing'),
+                cancelTitle: this.translateService.instant('Discard changes'),
+                confirmTitle: this.translateService.instant('Update'),
+            },
+        });
+        this.pendingConfirmLeaveDialog = dialogRef.afterClosed().pipe(
+            switchMap((dialogResult: ConfirmDialogAction | undefined) => {
+                if (dialogResult === 'confirm') {
+                    return from(this.saveAssetChanges()).pipe(map(() => true));
+                }
+
+                if (dialogResult === 'cancel') {
+                    return of(true);
+                }
+
+                return of(false);
+            }),
+            finalize(() => (this.pendingConfirmLeaveDialog = undefined)),
+            shareReplay({ bufferSize: 1, refCount: true }),
+        );
+        return this.pendingConfirmLeaveDialog;
     }
 
     setShouldShowConfirm(): boolean {

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
@@ -323,9 +323,12 @@ export class SpAssetDetailsComponent
             return false;
         }
         return (
-            JSON.stringify(
+            this.stringifyForComparison(
                 this.normalizeAssetForComparison(this.originalAsset),
-            ) !== JSON.stringify(this.normalizeAssetForComparison(this.asset))
+            ) !==
+            this.stringifyForComparison(
+                this.normalizeAssetForComparison(this.asset),
+            )
         );
     }
 
@@ -362,5 +365,32 @@ export class SpAssetDetailsComponent
 
     private cloneAsset(asset: SpAssetModel): SpAssetModel {
         return JSON.parse(JSON.stringify(asset));
+    }
+
+    private stringifyForComparison(asset: SpAssetModel): string {
+        return JSON.stringify(this.sortObjectKeys(asset));
+    }
+
+    private sortObjectKeys(value: unknown): unknown {
+        if (Array.isArray(value)) {
+            return value.map(entry => this.sortObjectKeys(entry));
+        }
+
+        if (value && typeof value === 'object') {
+            return Object.keys(value)
+                .sort()
+                .reduce(
+                    (sortedValue, key) => {
+                        const entry = (value as Record<string, unknown>)[key];
+                        if (entry !== undefined) {
+                            sortedValue[key] = this.sortObjectKeys(entry);
+                        }
+                        return sortedValue;
+                    },
+                    {} as Record<string, unknown>,
+                );
+        }
+
+        return value;
     }
 }

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
@@ -328,12 +328,9 @@ export class SpAssetDetailsComponent
             return false;
         }
         return (
-            this.stringifyForComparison(
+            JSON.stringify(
                 this.normalizeAssetForComparison(this.originalAsset),
-            ) !==
-            this.stringifyForComparison(
-                this.normalizeAssetForComparison(this.asset),
-            )
+            ) !== JSON.stringify(this.normalizeAssetForComparison(this.asset))
         );
     }
 
@@ -369,33 +366,6 @@ export class SpAssetDetailsComponent
     }
 
     private cloneAsset(asset: SpAssetModel): SpAssetModel {
-        return JSON.parse(JSON.stringify(asset));
-    }
-
-    private stringifyForComparison(asset: SpAssetModel): string {
-        return JSON.stringify(this.sortObjectKeys(asset));
-    }
-
-    private sortObjectKeys(value: unknown): unknown {
-        if (Array.isArray(value)) {
-            return value.map(entry => this.sortObjectKeys(entry));
-        }
-
-        if (value && typeof value === 'object') {
-            return Object.keys(value)
-                .sort()
-                .reduce(
-                    (sortedValue, key) => {
-                        const entry = (value as Record<string, unknown>)[key];
-                        if (entry !== undefined) {
-                            sortedValue[key] = this.sortObjectKeys(entry);
-                        }
-                        return sortedValue;
-                    },
-                    {} as Record<string, unknown>,
-                );
-        }
-
-        return value;
+        return SpAssetModel.fromData(asset);
     }
 }

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.ts
@@ -91,6 +91,8 @@ export class SpAssetDetailsComponent
 
     private pendingManageAssetResult?: ObjectManageDialogResult<ManageableAsset>;
     private originalAsset: SpAssetModel;
+    private initialGeneratedAssetId?: string;
+    private initialGeneratedElementId?: string;
 
     async saveAsset() {
         if (this.isNewAsset && this.pendingManageAssetResult === undefined) {
@@ -265,7 +267,11 @@ export class SpAssetDetailsComponent
     }
 
     onAssetAvailable() {
-        this.originalAsset = this.cloneAsset(this.asset);
+        if (this.isNewAsset) {
+            this.initialGeneratedAssetId = this.asset.assetId;
+            this.initialGeneratedElementId = this.asset.elementId;
+        }
+        this.originalAsset = this.normalizeAssetForComparison(this.asset);
     }
 
     private makeManageableAsset(asset: SpAssetModel): ManageableAsset {
@@ -294,7 +300,7 @@ export class SpAssetDetailsComponent
             await firstValueFrom(this.assetService.updateAsset(this.asset));
         }
         await this.savePendingManageAssetChanges();
-        this.originalAsset = this.cloneAsset(this.asset);
+        this.originalAsset = this.normalizeAssetForComparison(this.asset);
     }
 
     private async savePendingManageAssetChanges(): Promise<void> {
@@ -316,11 +322,42 @@ export class SpAssetDetailsComponent
         if (!this.originalAsset || !this.asset) {
             return false;
         }
-
         return (
-            JSON.stringify(this.originalAsset) !==
-            JSON.stringify(this.cloneAsset(this.asset))
+            JSON.stringify(
+                this.normalizeAssetForComparison(this.originalAsset),
+            ) !== JSON.stringify(this.normalizeAssetForComparison(this.asset))
         );
+    }
+
+    private normalizeAssetForComparison(asset: SpAssetModel): SpAssetModel {
+        const clonedAsset = this.cloneAsset(asset);
+        if (this.isNewAsset) {
+            if (clonedAsset.assetName === 'New Asset') {
+                clonedAsset.assetName = '';
+            }
+            if (clonedAsset.assetId === this.initialGeneratedAssetId) {
+                clonedAsset.assetId = '';
+            }
+            if (clonedAsset.elementId === this.initialGeneratedElementId) {
+                clonedAsset.elementId = '';
+            }
+        }
+        clonedAsset.additionalData ??= {};
+        clonedAsset.additionalData.customFields ??= [];
+        clonedAsset.assetSite ??= {
+            area: undefined,
+            siteId: undefined,
+            hasExactLocation: false,
+            location: undefined,
+        };
+        clonedAsset.assetType ??= {
+            assetIcon: undefined,
+            assetIconColor: undefined,
+            assetTypeCategory: undefined,
+            assetTypeLabel: undefined,
+            isa95AssetType: 'OTHER',
+        };
+        return clonedAsset;
     }
 
     private cloneAsset(asset: SpAssetModel): SpAssetModel {


### PR DESCRIPTION
- Checks for pending confirm dialogs 
- disable confirm dialog if no changes were made in create mode