### PR TITLE
feat: implement consistent keyboard shortcuts and sequence navigation

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -25,6 +25,7 @@ src/app/home/home.service.ts
 src/app/services/version/version.service.ts
 src/app/services/app.constants.ts
 src/app/core/components/base-navigation.component.ts
+src/app/core/navigation/nav-menu.service.ts
 src/assets/img/sp/logo.png
 src/assets/img/sp/logo-navigation.png
 src/assets/img/favicon/favicon-96x96.png

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -24,6 +24,7 @@ cypress/fixtures/**/*.csv
 # Ignore files that are overriden from the prebuild script
 src/app/app.routes.ts
 src/app/core/components/base-navigation.component.ts
+src/app/core/navigation/nav-menu.service.ts
 src/app/home/home.service.ts
 deployment/*.mst
 

--- a/ui/angular.json
+++ b/ui/angular.json
@@ -88,7 +88,7 @@
           "builder": "@angular/build:karma",
           "options": {
             "main": "src/test.ts",
-            "polyfills": "src/polyfills.ts",
+            "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "assets": ["src/assets"],

--- a/ui/deployment/base-navigation.component.mst
+++ b/ui/deployment/base-navigation.component.mst
@@ -26,6 +26,7 @@ import { UserPrivilege } from '../auth/user-privilege.enum';
 import { UserRole } from '../auth/user-role.enum';
 import { inject } from '@angular/core';
 import { CollapseService } from '../collapse.service';
+import { NavMenuService } from '../navigation/nav-menu.service';
 
 export interface MenuItem {
   link: string;
@@ -35,6 +36,7 @@ export interface MenuItem {
   privileges: any[];
   visible?: boolean;
   category: string;
+  shortcutKey?: string;
 }
 
 export interface MenuGroup {
@@ -67,19 +69,8 @@ export abstract class BaseNavigationComponent {
     {{/categoriesActive}}
   ];
 
-  public menu = [
-    {{#modulesActive}}
-    {
-        link: '{{{link}}}',
-        title: '{{{title}}}',
-        icon: '{{{icon}}}',
-        pageNames: [{{{pageNames}}}],
-        privileges: {{{privileges}}},
-        visible: false,
-        category: '{{{category}}}'
-    },
-    {{/modulesActive}}
-  ];
+   protected navMenuService = inject(NavMenuService);
+   public menu = this.navMenuService.items;
 
    protected authService = inject(AuthService);
    protected currentUserService = inject(CurrentUserService);

--- a/ui/deployment/modules.yml
+++ b/ui/deployment/modules.yml
@@ -23,6 +23,7 @@ spAssets:
     pageNames: 'PageName.ASSETS'
     showStatusBox: false
     category: 'management'
+    shortcutKey: 'a'
 spDatasets:
     routesPath: './dataset/dataset.routes'
     routesName: DATASET_ROUTES
@@ -33,6 +34,7 @@ spDatasets:
     pageNames: 'PageName.DATASETS'
     showStatusBox: false
     category: 'management'
+    shortcutKey: 'y'
 spHome:
     routesPath: './home/home.routes'
     routesName: HOME_ROUTES
@@ -44,6 +46,7 @@ spHome:
     guard: 'canActivate: [ConfiguredCanActivateGuard], '
     showStatusBox: false
     category: 'top'
+    shortcutKey: 'h'
 spConnect:
     routesPath: './connect/connect.routes'
     routesName: CONNECT_ROUTES
@@ -63,6 +66,7 @@ spConnect:
         viewRoles: '[UserPrivilege.PRIVILEGE_READ_ADAPTER, UserPrivilege.PRIVILEGE_WRITE_ADAPTER]'
         createRoles: '[UserPrivilege.PRIVILEGE_WRITE_ADAPTER]'
     category: 'management'
+    shortcutKey: 'c'
 spPipelines:
     routesPath: './pipelines/pipelines.routes'
     routesName: PIPELINES_ROUTES
@@ -82,6 +86,7 @@ spPipelines:
         viewRoles: '[UserPrivilege.PRIVILEGE_READ_PIPELINE, UserPrivilege.PRIVILEGE_WRITE_PIPELINE]'
         createRoles: '[UserPrivilege.PRIVILEGE_WRITE_PIPELINE]'
     category: 'analytics'
+    shortcutKey: 'p'
 spConfiguration:
     routesPath: './configuration/configuration.routes'
     routesName: CONFIGURATION_ROUTES
@@ -92,6 +97,7 @@ spConfiguration:
     privileges: '[UserPrivilege.PRIVILEGE_WRITE_ASSETS, UserPrivilege.PRIVILEGE_WRITE_LABELS, UserPrivilege.PRIVILEGE_WRITE_FILES]'
     showStatusBox: false
     category: 'management'
+    shortcutKey: 's'
 spDashboard:
     routesPath: './dashboard/dashboard.routes'
     routesName: DASHBOARD_ROUTES
@@ -111,6 +117,7 @@ spDashboard:
         viewRoles: '[UserPrivilege.PRIVILEGE_READ_DASHBOARD, UserPrivilege.PRIVILEGE_WRITE_DASHBOARD]'
         createRoles: '[UserPrivilege.PRIVILEGE_WRITE_DASHBOARD]'
     category: 'visualization'
+    shortcutKey: 'd'
 spChart:
     routesPath: './chart/chart.routes'
     routesName: CHART_ROUTES
@@ -131,3 +138,4 @@ spChart:
         viewRoles: '[UserPrivilege.PRIVILEGE_READ_DATA_EXPLORER_VIEW, UserPrivilege.PRIVILEGE_WRITE_DATA_EXPLORER_VIEW]'
         createRoles: '[UserPrivilege.PRIVILEGE_WRITE_DATA_EXPLORER_VIEW]'
     category: 'visualization'
+    shortcutKey: 'e'

--- a/ui/deployment/nav-menu.service.mst
+++ b/ui/deployment/nav-menu.service.mst
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { Injectable } from '@angular/core';
+import { UserPrivilege } from '../auth/user-privilege.enum';
+import { PageName } from './page-name.enum';
+
+export interface NavMenuItem {
+    link: string;
+    title: string;
+    icon: string;
+    pageNames: any[];
+    privileges: any[];
+    visible?: boolean;
+    category: string;
+    shortcutKey?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NavMenuService {
+    public items: NavMenuItem[] = [
+        {{#modulesActive}}
+        {
+            link: '{{{link}}}',
+            title: '{{{title}}}',
+            icon: '{{{icon}}}',
+            pageNames: [{{{pageNames}}}],
+            privileges: {{{privileges}}},
+            category: '{{{category}}}',
+            shortcutKey: '{{{shortcutKey}}}'
+        },
+        {{/modulesActive}}
+    ];
+}

--- a/ui/deployment/prebuild.js
+++ b/ui/deployment/prebuild.js
@@ -122,6 +122,7 @@ for (let module of config.modules) {
         category: modules[module]['category'],
         featureCards: cardsForModule,
         hasFeatureCards: cardsForModule.length > 0,
+        shortcutKey: modules[module]['shortcutKey'],
     });
     console.log('Active Angular Module: ' + module);
 }
@@ -138,6 +139,13 @@ fs.writeFileSync(
     'src/app/home/home.service.ts',
     mustache.render(
         fs.readFileSync('deployment/home.service.mst', 'utf8').toString(),
+        modulesActive,
+    ),
+);
+fs.writeFileSync(
+    'src/app/core/navigation/nav-menu.service.ts',
+    mustache.render(
+        fs.readFileSync('deployment/nav-menu.service.mst', 'utf8').toString(),
         modulesActive,
     ),
 );

--- a/ui/projects/streampipes/shared-ui/src/lib/services/keyboard-shortcut.service.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/services/keyboard-shortcut.service.ts
@@ -24,9 +24,16 @@ export interface ShortcutAction {
     key: string;
     ctrl?: boolean;
     shift?: boolean;
+    alt?: boolean;
     action: (event: KeyboardEvent) => void;
     preventDefault?: boolean;
     allowInDialog?: boolean;
+}
+
+export interface SequenceAction {
+    sequence: [string, string]; // e.g. ['g', 'p']
+    action: (event: KeyboardEvent) => void;
+    preventDefault?: boolean;
 }
 
 export type ShortcutRegistration = { unregister: () => void };
@@ -35,6 +42,11 @@ export type ShortcutRegistration = { unregister: () => void };
 export class KeyboardShortcutService implements OnDestroy {
     private keydown$ = new Subject<KeyboardEvent>();
     private registrations: Map<string, ShortcutAction[]> = new Map();
+    private sequenceRegistrations: Map<string, SequenceAction[]> = new Map();
+    private pendingSequenceKey: string | null = null;
+    private pendingSequenceTimeout: any = null;
+    private readonly SEQUENCE_TIMEOUT_MS = 1000;
+
     private listener = (e: KeyboardEvent) => {
         const isInput = this.isInputFocused(e);
         const ctrl = e.ctrlKey || e.metaKey;
@@ -58,29 +70,83 @@ export class KeyboardShortcutService implements OnDestroy {
     ngOnDestroy(): void {
         document.removeEventListener('keydown', this.listener, true);
         this.keydown$.complete();
+        this.clearPendingSequence();
     }
 
     register(id: string, actions: ShortcutAction[]): ShortcutRegistration {
         this.registrations.set(id, actions);
-        return { unregister: () => this.registrations.delete(id) };
+        return { unregister: () => this.unregister(id) };
+    }
+
+    registerSequences(
+        id: string,
+        actions: SequenceAction[],
+    ): ShortcutRegistration {
+        this.sequenceRegistrations.set(id, actions);
+        return { unregister: () => this.unregister(id) };
     }
 
     unregister(id: string): void {
         this.registrations.delete(id);
+        this.sequenceRegistrations.delete(id);
     }
 
     private handleEvent(event: KeyboardEvent): void {
         const key = event.key.toLowerCase();
         const ctrl = event.ctrlKey || event.metaKey;
         const shift = event.shiftKey;
+        const alt = event.altKey;
 
+        // 1. If a sequence is pending, THIS keystroke completes or cancels it —
+        //    it never falls through to single-key matching.
+        if (this.pendingSequenceKey) {
+            const firstKey = this.pendingSequenceKey;
+            this.clearPendingSequence();
+
+            const seqMatch = Array.from(this.sequenceRegistrations.values())
+                .flat()
+                .find(a => a.sequence[0] === firstKey && a.sequence[1] === key);
+
+            if (seqMatch) {
+                if (seqMatch.preventDefault !== false) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                if (!this.dialogService.hasOpenDialogs) {
+                    seqMatch.action(event);
+                }
+                return;
+            }
+            // no match: fall through and evaluate this key normally (don't return)
+        }
+
+        // 2. Does this key start a known sequence (no modifiers held)?
+        const startsSequence =
+            !ctrl &&
+            !shift &&
+            !alt &&
+            Array.from(this.sequenceRegistrations.values())
+                .flat()
+                .some(a => a.sequence[0] === key);
+
+        if (startsSequence) {
+            this.pendingSequenceKey = key;
+            this.pendingSequenceTimeout = setTimeout(
+                () => this.clearPendingSequence(),
+                this.SEQUENCE_TIMEOUT_MS,
+            );
+            return; // don't evaluate single-key matches for the first key either
+        }
+
+        // 3. Existing single-key/combo matching (unchanged, but add alt check)
         const match = Array.from(this.registrations.values())
             .flat()
             .find(
                 a =>
                     a.key.toLowerCase() === key &&
                     !!a.ctrl === ctrl &&
-                    !!a.shift === shift,
+                    !!a.shift === shift &&
+                    !!a.alt === alt,
             );
 
         if (match) {
@@ -88,11 +154,18 @@ export class KeyboardShortcutService implements OnDestroy {
                 event.preventDefault();
                 event.stopPropagation();
             }
-
             if (!this.dialogService.hasOpenDialogs || match.allowInDialog) {
                 match.action(event);
             }
         }
+    }
+
+    private clearPendingSequence(): void {
+        if (this.pendingSequenceTimeout) {
+            clearTimeout(this.pendingSequenceTimeout);
+        }
+        this.pendingSequenceKey = null;
+        this.pendingSequenceTimeout = null;
     }
 
     private isInputFocused = (event: KeyboardEvent): boolean => {

--- a/ui/src/app/core/components/streampipes/streampipes.component.ts
+++ b/ui/src/app/core/components/streampipes/streampipes.component.ts
@@ -18,15 +18,22 @@
 
 import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { animate, style, transition, trigger } from '@angular/animations';
-import { CurrentUserService } from '@streampipes/shared-ui';
+import {
+    CurrentUserService,
+    KeyboardShortcutService,
+    ShortcutRegistration,
+    ShortcutAction,
+    SequenceAction,
+} from '@streampipes/shared-ui';
 import { TranslateService } from '@ngx-translate/core';
 import { CollapseService } from '../../collapse.service';
+import { NavMenuService } from '../../navigation/nav-menu.service';
 import { Subscription } from 'rxjs';
 import { NgClass } from '@angular/common';
 import { ClassDirective } from '@ngbracket/ngx-layout/extended';
 import { IconbarComponent } from '../iconbar/iconbar.component';
 import { ToolbarComponent } from '../toolbar/toolbar.component';
-import { RouterOutlet } from '@angular/router';
+import { Router, RouterOutlet } from '@angular/router';
 
 @Component({
     selector: 'sp-streampipes',
@@ -55,9 +62,14 @@ export class StreampipesComponent implements OnInit, OnDestroy {
     private translate = inject(TranslateService);
     private collapseService = inject(CollapseService);
     private currentUserService = inject(CurrentUserService);
+    private shortcutService = inject(KeyboardShortcutService);
+    private router = inject(Router);
+    private navMenuService = inject(NavMenuService);
 
     darkMode$: Subscription;
     user$: Subscription;
+    private shortcutReg: ShortcutRegistration;
+    private shortcutSeqReg: ShortcutRegistration;
 
     collapsed = this.collapseService.isCollapsed;
 
@@ -77,10 +89,50 @@ export class StreampipesComponent implements OnInit, OnDestroy {
                 this.translate.use(user.language);
             }
         });
+
+        const singleKeyActions: ShortcutAction[] = [
+            {
+                key: '?',
+                shift: true,
+                action: () => this.router.navigateByUrl('help'),
+            },
+            {
+                key: 'b',
+                ctrl: true,
+                action: () => this.collapseService.toggleMenubar(),
+            },
+            {
+                key: 'b',
+                alt: true,
+                action: () => this.collapseService.toggleMenubar(),
+            },
+        ];
+
+        const sequenceActions: SequenceAction[] = this.navMenuService.items
+            .filter(item => !!item.shortcutKey)
+            .map(item => ({
+                sequence: ['g', item.shortcutKey] as [string, string],
+                action: () => {
+                    if (item.visible !== false) {
+                        this.router.navigateByUrl(item.link || '');
+                    }
+                },
+            }));
+
+        this.shortcutReg = this.shortcutService.register(
+            'streampipes-global',
+            singleKeyActions,
+        );
+        this.shortcutSeqReg = this.shortcutService.registerSequences(
+            'streampipes-global',
+            sequenceActions,
+        );
     }
 
     ngOnDestroy() {
         this.darkMode$?.unsubscribe();
         this.user$?.unsubscribe();
+        this.shortcutReg?.unregister();
+        this.shortcutSeqReg?.unregister();
     }
 }

--- a/ui/src/app/help/components/shortcuts/shortcuts.component.ts
+++ b/ui/src/app/help/components/shortcuts/shortcuts.component.ts
@@ -21,6 +21,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FlexDirective, LayoutDirective } from '@ngbracket/ngx-layout/flex';
 import { SpBasicHeaderTitleComponent } from '@streampipes/shared-ui';
 import { TranslateService } from '@ngx-translate/core';
+import { NavMenuService } from '../../../core/navigation/nav-menu.service';
 
 interface ShortcutDefinition {
     combo: string;
@@ -52,6 +53,7 @@ const SHORTCUT_TRANSLATION_KEYS = {
 })
 export class ShortcutsTabComponent {
     private translateService = inject(TranslateService);
+    private navMenuService = inject(NavMenuService);
 
     title = '';
     shortcuts: ShortcutDefinition[] = [];
@@ -115,6 +117,29 @@ export class ShortcutsTabComponent {
                             ],
                     },
                 ];
+
+                this.shortcuts.push(
+                    ...this.navMenuService.items
+                        .filter(
+                            item =>
+                                !!item.shortcutKey && item.visible !== false,
+                        )
+                        .map(item => ({
+                            combo: `g then ${item.shortcutKey}`,
+                            context: 'Anywhere outside inputs',
+                            description: `Navigate to ${item.title}`,
+                        })),
+                    {
+                        combo: '?',
+                        context: 'Anywhere outside inputs',
+                        description: 'Open help page',
+                    },
+                    {
+                        combo: 'Ctrl + B / Alt + B',
+                        context: 'Anywhere',
+                        description: 'Toggle sidebar menu',
+                    },
+                );
             });
     }
 }

--- a/ui/src/app/keyboard-shortcut.service.spec.ts
+++ b/ui/src/app/keyboard-shortcut.service.spec.ts
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { KeyboardShortcutService, DialogService } from '@streampipes/shared-ui';
+
+describe('KeyboardShortcutService', () => {
+    let service: KeyboardShortcutService;
+    let mockDialogService: any;
+
+    beforeEach(() => {
+        mockDialogService = {
+            hasOpenDialogs: false,
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                KeyboardShortcutService,
+                { provide: DialogService, useValue: mockDialogService },
+            ],
+        });
+
+        service = TestBed.inject(KeyboardShortcutService);
+    });
+
+    afterEach(() => {
+        service.ngOnDestroy();
+    });
+
+    it('should fire single-key registered shortcut', () => {
+        let fired = false;
+        service.register('test', [
+            {
+                key: 'a',
+                action: () => {
+                    fired = true;
+                },
+            },
+        ]);
+
+        const event = new KeyboardEvent('keydown', { key: 'a' });
+        document.dispatchEvent(event);
+
+        expect(fired).toBe(true);
+    });
+
+    it('should match Alt combos', () => {
+        let fired = false;
+        service.register('test', [
+            {
+                key: 'b',
+                alt: true,
+                action: () => {
+                    fired = true;
+                },
+            },
+        ]);
+
+        // Dispatch keydown b without alt
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'b', altKey: false }),
+        );
+        expect(fired).toBe(false);
+
+        // Dispatch keydown b with alt
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'b', altKey: true }),
+        );
+        expect(fired).toBe(true);
+    });
+
+    it('should fire sequence action within timeout', fakeAsync(() => {
+        let fired = false;
+        service.registerSequences('test', [
+            {
+                sequence: ['g', 'p'],
+                action: () => {
+                    fired = true;
+                },
+            },
+        ]);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+        tick(500); // 500ms elapsed
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+        expect(fired).toBe(true);
+    }));
+
+    it('should NOT fire sequence action if timeout elapsed', fakeAsync(() => {
+        let fired = false;
+        service.registerSequences('test', [
+            {
+                sequence: ['g', 'p'],
+                action: () => {
+                    fired = true;
+                },
+            },
+        ]);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+        tick(1001); // timeout elapsed
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+        expect(fired).toBe(false);
+    }));
+
+    it('should give sequence precedence over single-key contextual shortcut', fakeAsync(() => {
+        let seqFired = false;
+        let singleFired = false;
+
+        service.registerSequences('global', [
+            {
+                sequence: ['g', 'e'],
+                action: () => {
+                    seqFired = true;
+                },
+            },
+        ]);
+
+        service.register('contextual', [
+            {
+                key: 'e',
+                action: () => {
+                    singleFired = true;
+                },
+            },
+        ]);
+
+        // Press 'g'
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'g' }));
+        tick(100);
+        // Press 'e' within sequence timeout
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'e' }));
+
+        expect(seqFired).toBe(true);
+        expect(singleFired).toBe(false);
+    }));
+
+    it('should ignore shortcut events when input field is focused', () => {
+        let fired = false;
+        service.register('test', [
+            {
+                key: 's',
+                action: () => {
+                    fired = true;
+                },
+            },
+        ]);
+
+        // Create an input element and focus it
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+
+        const event = new KeyboardEvent('keydown', {
+            key: 's',
+            bubbles: true,
+        });
+        Object.defineProperty(event, 'target', {
+            value: input,
+            enumerable: true,
+        });
+
+        input.dispatchEvent(event);
+
+        expect(fired).toBe(false);
+
+        // Cleanup
+        document.body.removeChild(input);
+    });
+});


### PR DESCRIPTION
### Purpose

Implements #4695 — a consistent keyboard shortcut concept across StreamPipes.

- **Global navigation:** `g` then a letter jumps to a module (`g p` → Pipelines,
  `g d` → Dashboards, `g c` → Adapters, `g e` → Charts, `g a` → Assets,
  `g y` → Datasets, `g s` → Settings, `g h` → Home). Driven by a new
  `shortcutKey` field on each module in `modules.yml`, generated into
  `NavMenuService` — no duplicated route mapping.
- **Global utilities:** `?` opens Help, `Ctrl+B` / `Alt+B` toggles the sidebar.
- **Contextual shortcuts** (`E` to edit, `Ctrl+S` to save, etc.) unchanged.
- `KeyboardShortcutService` extended to support two-key sequences (1000ms
  timeout) alongside existing single-key/modifier shortcuts, plus new `alt`
  modifier support.
- Help page's Shortcuts tab now lists the navigation shortcuts dynamically
  from `NavMenuService`, so it stays in sync with active modules.
- Added unit tests: sequence fire/timeout, sequence precedence over a
  same-key contextual shortcut, alt-combo match, input-focus suppression.

### How to test

1. `npm install && npm run build-libraries && npm run build-dev`
2. Outside an input, press `g` then `p`/`d`/`c`/`e`/`a`/`y`/`s`/`h` → navigates.
3. Press `g`, wait >1s, then a letter → no navigation (timeout works).
4. Press `?` → Help opens; shortcuts listed there.
5. Press `Ctrl+B` / `Alt+B` → sidebar toggles.
6. `npm test` → `keyboard-shortcut.service.spec.ts` (6/6 passing).

### Remarks

While a `g`-sequence is pending, its second key always takes precedence over
a same-key contextual shortcut on that view (e.g. `g` `e` navigates to Charts
rather than triggering local edit mode). Intentional tradeoff for simplicity.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no