### PR TITLE
fix: Fix adapter script migration for file stream adapter

### DIFF
--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/compact/generator/AdapterSchemaGenerator.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/compact/generator/AdapterSchemaGenerator.java
@@ -62,8 +62,8 @@ public class AdapterSchemaGenerator implements AdapterModelGenerator {
     adapterDescription.getTransformationConfig()
                       .setInputs(sampleData.getSamples());
 
-    setDefaultScriptIfNotSet(adapterDescription);
-    setDefaultScriptLanguageIfNotSet(adapterDescription);
+    adapterDescription.getTransformationConfig()
+                      .applyScriptDefaults();
 
     guessManagement.transformSampleData(adapterDescription, userId);
 
@@ -88,31 +88,4 @@ public class AdapterSchemaGenerator implements AdapterModelGenerator {
     }
   }
 
-  private void setDefaultScriptIfNotSet(AdapterDescription adapterDescription) {
-    if (adapterDescription.getTransformationConfig()
-                          .getScript() == null
-        || adapterDescription.getTransformationConfig()
-                             .getScript()
-                             .isEmpty()) {
-      adapterDescription.getTransformationConfig().setScriptActive(true);
-      adapterDescription.getTransformationConfig()
-                        .setScript("""
-                                   function transform(event, out, ctx) {
-                                      out.collect(event);
-                                    }
-                                   """);
-
-    }
-  }
-
-  private void setDefaultScriptLanguageIfNotSet(AdapterDescription adapterDescription) {
-    if (adapterDescription.getTransformationConfig()
-                          .getLanguage() == null
-        || adapterDescription.getTransformationConfig()
-                             .getLanguage()
-                             .isEmpty()) {
-      adapterDescription.getTransformationConfig()
-                        .setLanguage("javascript");
-    }
-  }
 }

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterMasterManagement.java
@@ -85,6 +85,7 @@ public class AdapterMasterManagement {
     var eventGrounding = GroundingUtils.createEventGrounding();
     adapterDescription.setEventGrounding(eventGrounding);
 
+    AdapterTransformationConfigDefaults.applyTo(adapterDescription);
     adapterResourceManager.encryptAndCreate(adapterDescription);
 
     // Stream is only created if the adpater is successfully stored

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterTransformationConfigDefaults.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterTransformationConfigDefaults.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.connect.management.management;
+
+import org.apache.streampipes.model.connect.TransformationConfig;
+import org.apache.streampipes.model.connect.adapter.AdapterDescription;
+
+class AdapterTransformationConfigDefaults {
+
+  private AdapterTransformationConfigDefaults() {
+  }
+
+  static void applyTo(AdapterDescription adapterDescription) {
+    if (adapterDescription.getTransformationConfig() == null) {
+      adapterDescription.setTransformationConfig(TransformationConfig.withDefaultScript());
+    } else {
+      adapterDescription.getTransformationConfig()
+                        .applyScriptDefaults();
+    }
+  }
+}

--- a/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterUpdateManagement.java
+++ b/streampipes-connect-management/src/main/java/org/apache/streampipes/connect/management/management/AdapterUpdateManagement.java
@@ -48,6 +48,7 @@ public class AdapterUpdateManagement {
   public void updateAdapter(AdapterDescription ad)
       throws AdapterException {
     // update adapter in database 
+    AdapterTransformationConfigDefaults.applyTo(ad);
     this.adapterResourceManager.encryptAndUpdate(ad);
     boolean shouldRestart = ad.isRunning();
 

--- a/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/java/org/apache/streampipes/connect/iiot/protocol/stream/FileReplayAdapter.java
+++ b/streampipes-extensions/streampipes-connect-adapters-iiot/src/main/java/org/apache/streampipes/connect/iiot/protocol/stream/FileReplayAdapter.java
@@ -196,17 +196,15 @@ public class FileReplayAdapter implements StreamPipesAdapter {
 
   protected void validateTimestampFieldInInputEvent(IAdapterParameterExtractor extractor)
       throws AdapterException {
-    var inputEvents = extractor.getAdapterDescription()
-                               .getTransformationConfig()
-                               .getInputs();
+    var sampleInputEvent = getSampleInputEvent(extractor);
 
-    if (inputEvents == null || inputEvents.isEmpty()) {
+    if (sampleInputEvent == null || sampleInputEvent.isEmpty()) {
       throw new AdapterException("Could not validate timestamp field in original input event. "
                                      + "No sample input event is available. The file replay adapter requires a Unix "
                                      + "timestamp to be present in the original input data.");
     }
 
-    var timestampFieldValue = inputEvents.get(0).get(timestampRuntimeName);
+    var timestampFieldValue = sampleInputEvent.get(timestampRuntimeName);
 
     if (!(timestampFieldValue instanceof Number)) {
       throw new AdapterException("The timestamp field in the original input event must be numeric. "
@@ -216,6 +214,27 @@ public class FileReplayAdapter implements StreamPipesAdapter {
           timestampFieldValue
       ));
     }
+  }
+
+  private Map<String, Object> getSampleInputEvent(IAdapterParameterExtractor extractor) throws AdapterException {
+    var transformationConfig = extractor.getAdapterDescription()
+                                        .getTransformationConfig();
+
+    if (transformationConfig != null
+        && transformationConfig.getInputs() != null
+        && !transformationConfig.getInputs().isEmpty()) {
+      return transformationConfig.getInputs().get(0);
+    }
+
+    var inputStream = getFileAsInputStreamFromEndpoint(extractor);
+    var sampleData = extractor.selectedParser().getSampleData(inputStream);
+    if (sampleData == null
+        || sampleData.getSamples() == null
+        || sampleData.getSamples().isEmpty()) {
+      return Map.of();
+    }
+
+    return sampleData.getSamples().get(0);
   }
 
   private void getFileFromEndpointAndParseFile(
@@ -329,7 +348,7 @@ public class FileReplayAdapter implements StreamPipesAdapter {
                     .getSampleData(inputStream);
   }
 
-  private InputStream getFileAsInputStreamFromEndpoint(IAdapterParameterExtractor extractor) throws AdapterException {
+  protected InputStream getFileAsInputStreamFromEndpoint(IAdapterParameterExtractor extractor) throws AdapterException {
     var selectedFileName = extractor
         .getStaticPropertyExtractor()
         .selectedFilename(FILE_PATH);

--- a/streampipes-extensions/streampipes-connect-adapters-iiot/src/test/java/org/apache/streampipes/connect/iiot/protocol/stream/FileReplayAdapterTest.java
+++ b/streampipes-extensions/streampipes-connect-adapters-iiot/src/test/java/org/apache/streampipes/connect/iiot/protocol/stream/FileReplayAdapterTest.java
@@ -20,19 +20,24 @@ package org.apache.streampipes.connect.iiot.protocol.stream;
 
 import org.apache.streampipes.commons.exceptions.connect.AdapterException;
 import org.apache.streampipes.extensions.api.connect.IEventCollector;
+import org.apache.streampipes.extensions.api.connect.IParser;
 import org.apache.streampipes.extensions.api.extractor.IAdapterParameterExtractor;
 import org.apache.streampipes.model.connect.adapter.AdapterDescription;
+import org.apache.streampipes.model.connect.guess.SampleData;
 import org.apache.streampipes.sdk.helpers.EpProperties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -113,6 +118,20 @@ class FileReplayAdapterTest {
   }
 
   @Test
+  void validateTimestampFieldInInputEvent_shouldUseParserSampleWhenOriginalInputIsEmpty() throws AdapterException {
+    var parser = mock(IParser.class);
+    var sampleData = new SampleData();
+    sampleData.setSamples(List.of(Map.of(TIMESTAMP, TIMESTAMP_VALUE)));
+    adapterDescription.getTransformationConfig().setInputs(List.of());
+    when(extractor.selectedParser()).thenReturn(parser);
+    when(parser.getSampleData(any(InputStream.class))).thenReturn(sampleData);
+    fileReplayAdapter = new TestFileReplayAdapter();
+    fileReplayAdapter.setTimestampRuntimeName(TIMESTAMP);
+
+    fileReplayAdapter.validateTimestampFieldInInputEvent(extractor);
+  }
+
+  @Test
   void validateTimestampFieldInInputEvent_shouldThrowForStringTimestampInOriginalInput() {
     adapterDescription.getTransformationConfig().setInputs(List.of(Map.of(TIMESTAMP, "2021-12-24T12:55:12.123+01:00")));
 
@@ -130,4 +149,11 @@ class FileReplayAdapterTest {
     assertEquals(Long.class, event.get(TIMESTAMP).getClass());
   }
 
+  private static class TestFileReplayAdapter extends FileReplayAdapter {
+
+    @Override
+    protected InputStream getFileAsInputStreamFromEndpoint(IAdapterParameterExtractor extractor) {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+  }
 }

--- a/streampipes-model/src/main/java/org/apache/streampipes/model/connect/TransformationConfig.java
+++ b/streampipes-model/src/main/java/org/apache/streampipes/model/connect/TransformationConfig.java
@@ -23,6 +23,12 @@ import java.util.List;
 import java.util.Map;
 
 public class TransformationConfig {
+  public static final String DEFAULT_LANGUAGE = "javascript";
+  public static final String DEFAULT_SCRIPT = """
+      function transform(event, out, ctx) {
+        out.collect(event);
+      }""";
+
   private boolean scriptActive;
   private String language;
   private String script;
@@ -35,6 +41,19 @@ public class TransformationConfig {
   public TransformationConfig() {
     this.inputs = new ArrayList<>();
     this.outputs = new ArrayList<>();
+    this.scriptActive = false;
+    this.language = DEFAULT_LANGUAGE;
+    this.script = DEFAULT_SCRIPT;
+  }
+
+  public void applyScriptDefaults() {
+    if (language == null || language.isBlank()) {
+      language = DEFAULT_LANGUAGE;
+    }
+
+    if (script == null || script.isBlank()) {
+      script = DEFAULT_SCRIPT;
+    }
   }
 
   public String getLanguage() {

--- a/streampipes-model/src/main/java/org/apache/streampipes/model/connect/TransformationConfig.java
+++ b/streampipes-model/src/main/java/org/apache/streampipes/model/connect/TransformationConfig.java
@@ -41,9 +41,12 @@ public class TransformationConfig {
   public TransformationConfig() {
     this.inputs = new ArrayList<>();
     this.outputs = new ArrayList<>();
-    this.scriptActive = false;
-    this.language = DEFAULT_LANGUAGE;
-    this.script = DEFAULT_SCRIPT;
+  }
+
+  public static TransformationConfig withDefaultScript() {
+    var config = new TransformationConfig();
+    config.applyScriptDefaults();
+    return config;
   }
 
   public void applyScriptDefaults() {

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/MigrateAdaptersToUseScript.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/MigrateAdaptersToUseScript.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 public class MigrateAdaptersToUseScript implements Migration {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrateAdaptersToUseScript.class);
-  private static final String SCRIPT_LANGUAGE = "javascript";
 
   private final IAdapterStorage adapterStorage;
 
@@ -52,17 +51,17 @@ public class MigrateAdaptersToUseScript implements Migration {
   }
 
   @Override
-  // Execute if there is an adapter with no transformation config or script
+  // Execute if an adapter still has legacy transformation rules or misses its script config
   public boolean shouldExecute() {
     List<AdapterDescription> adapters = adapterStorage.findAll();
-    return adapters != null && adapters.stream().anyMatch(this::hasEmptyTransformationConfig);
+    return adapters != null && adapters.stream().anyMatch(this::shouldMigrate);
   }
 
   @Override
   public void executeMigration() throws IOException {
     adapterStorage.findAll()
         .stream()
-        .filter(this::hasEmptyTransformationConfig)
+        .filter(this::shouldMigrate)
         .forEach(this::migrateAndUpdateAdapter);
   }
 
@@ -71,8 +70,19 @@ public class MigrateAdaptersToUseScript implements Migration {
     return "Changes the rules based adapters to use script based transformations instead.";
   }
 
-  private boolean hasEmptyTransformationConfig(AdapterDescription adapter) {
-    return adapter.getTransformationConfig() == null || adapter.getTransformationConfig().getScript() == null;
+  private boolean shouldMigrate(AdapterDescription adapter) {
+    return adapter.getTransformationConfig() == null
+        || hasNoScript(adapter)
+        || hasLegacyRules(adapter);
+  }
+
+  private boolean hasNoScript(AdapterDescription adapter) {
+    var script = adapter.getTransformationConfig().getScript();
+    return script == null || script.isBlank();
+  }
+
+  private boolean hasLegacyRules(AdapterDescription adapter) {
+    return adapter.getRules() != null && !adapter.getRules().isEmpty();
   }
 
   private void migrateAndUpdateAdapter(AdapterDescription adapterDescription) {
@@ -125,7 +135,7 @@ public class MigrateAdaptersToUseScript implements Migration {
 
   private TransformationConfig initializeTransformationConfig(TransformationConfig oldConfig) {
     var config = new TransformationConfig();
-    config.setLanguage(SCRIPT_LANGUAGE);
+    config.setLanguage(TransformationConfig.DEFAULT_LANGUAGE);
 
     if (oldConfig == null) {
       return config;

--- a/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/MigrateAdaptersToUseScript.java
+++ b/streampipes-service-core/src/main/java/org/apache/streampipes/service/core/migrations/v099/connect/MigrateAdaptersToUseScript.java
@@ -36,11 +36,13 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class MigrateAdaptersToUseScript implements Migration {
 
   private static final Logger LOG = LoggerFactory.getLogger(MigrateAdaptersToUseScript.class);
+  private static final String SCRIPT_LANGUAGE = "javascript";
 
   private final IAdapterStorage adapterStorage;
 
@@ -86,7 +88,7 @@ public class MigrateAdaptersToUseScript implements Migration {
     removeAdditionalMetadata(adapter);
 
     // migration logic for a single adapter
-    var config = initializeTransformationConfig();
+    var config = initializeTransformationConfig(adapter.getTransformationConfig());
 
     var scriptBuilder = TransformationScriptBuilder.create();
 
@@ -121,12 +123,24 @@ public class MigrateAdaptersToUseScript implements Migration {
   }
 
 
-  private TransformationConfig initializeTransformationConfig() {
+  private TransformationConfig initializeTransformationConfig(TransformationConfig oldConfig) {
     var config = new TransformationConfig();
-    config.setLanguage("javascript");
-    config.setInputs(new ArrayList<>());
-    config.setOutputs(new ArrayList<>());
+    config.setLanguage(SCRIPT_LANGUAGE);
+
+    if (oldConfig == null) {
+      return config;
+    }
+
+    config.setInputs(copyOrEmpty(oldConfig.getInputs()));
+    config.setOutputs(copyOrEmpty(oldConfig.getOutputs()));
+    config.setReduceEventRateRule(oldConfig.getReduceEventRateRule());
+    config.setRemoveDuplicateRule(oldConfig.getRemoveDuplicateRule());
+
     return config;
+  }
+
+  private List<Map<String, Object>> copyOrEmpty(List<Map<String, Object>> values) {
+    return values == null ? new ArrayList<>() : new ArrayList<>(values);
   }
 
   /**

--- a/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
+++ b/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
@@ -19,6 +19,9 @@
 package org.apache.streampipes.service.core.migrations.v099;
 
 import org.apache.streampipes.model.SpDataStream;
+import org.apache.streampipes.model.connect.ReduceEventRateRule;
+import org.apache.streampipes.model.connect.RemoveDuplicateRule;
+import org.apache.streampipes.model.connect.TransformationConfig;
 import org.apache.streampipes.model.connect.adapter.AdapterDescription;
 import org.apache.streampipes.model.connect.rules.TransformationRuleDescription;
 import org.apache.streampipes.model.connect.rules.schema.DeleteRuleDescription;
@@ -47,10 +50,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -81,9 +86,21 @@ class MigrateAdaptersToUseScriptTest {
   }
 
   @Test
+  void shouldExecute_ReturnsTrue_WhenAdapterHasLegacyRulesAndDefaultScript() {
+    var adapter = createBaseAdapter(new RenameRuleDescription("old", "new"));
+
+    when(mockStorage.findAll()).thenReturn(List.of(adapter));
+
+    boolean result = migration.shouldExecute();
+
+    assertTrue(result);
+  }
+
+  @Test
   void executeMigration_RemoveAdditionalMetadata() throws IOException {
     // Arrange
     var adapter = new AdapterDescription();
+    adapter.getTransformationConfig().setScript(null);
     var eventPropertyPrimitive = new EventPropertyPrimitive();
     eventPropertyPrimitive.setAdditionalMetadata(Collections.singletonMap("key", "value"));
     var eventSchema = new EventSchema();
@@ -111,6 +128,66 @@ class MigrateAdaptersToUseScriptTest {
 
     // Verify the storage was actually updated
     verify(mockStorage).updateElement(adapter);
+  }
+
+  @Test
+  void executeMigration_KeepsInputsAndOutputsNonNull_WhenExistingConfigHasNullLists() throws IOException {
+    var adapter = createBaseAdapterWithoutRules();
+    var oldConfig = new TransformationConfig();
+    oldConfig.setScript(null);
+    oldConfig.setInputs(null);
+    oldConfig.setOutputs(null);
+    adapter.setTransformationConfig(oldConfig);
+
+    when(mockStorage.findAll()).thenReturn(List.of(adapter));
+
+    migration.executeMigration();
+
+    var resultConfig = adapter.getTransformationConfig();
+    assertNotNull(resultConfig.getInputs());
+    assertTrue(resultConfig.getInputs().isEmpty());
+    assertNotNull(resultConfig.getOutputs());
+    assertTrue(resultConfig.getOutputs().isEmpty());
+    verify(mockStorage).updateElement(adapter);
+  }
+
+  @Test
+  void executeMigration_CopiesExistingTransformationConfigValues() throws IOException {
+    var input = new HashMap<String, Object>();
+    input.put("runtimeName", "temperature");
+    var output = new HashMap<String, Object>();
+    output.put("runtimeName", "temperature_celsius");
+
+    var inputs = new ArrayList<Map<String, Object>>();
+    inputs.add(input);
+    var outputs = new ArrayList<Map<String, Object>>();
+    outputs.add(output);
+
+    var reduceEventRateRule = new ReduceEventRateRule(10, "mean");
+    var removeDuplicateRule = new RemoveDuplicateRule("500");
+
+    var oldConfig = new TransformationConfig();
+    oldConfig.setScript(null);
+    oldConfig.setInputs(inputs);
+    oldConfig.setOutputs(outputs);
+    oldConfig.setReduceEventRateRule(reduceEventRateRule);
+    oldConfig.setRemoveDuplicateRule(removeDuplicateRule);
+
+    var adapter = createBaseAdapterWithoutRules();
+    adapter.setTransformationConfig(oldConfig);
+
+    when(mockStorage.findAll()).thenReturn(List.of(adapter));
+
+    migration.executeMigration();
+
+    var resultConfig = adapter.getTransformationConfig();
+    assertEquals(TransformationConfig.DEFAULT_LANGUAGE, resultConfig.getLanguage());
+    assertEquals(inputs, resultConfig.getInputs());
+    assertEquals(outputs, resultConfig.getOutputs());
+    assertNotSame(inputs, resultConfig.getInputs());
+    assertNotSame(outputs, resultConfig.getOutputs());
+    assertEquals(reduceEventRateRule, resultConfig.getReduceEventRateRule());
+    assertEquals(removeDuplicateRule, resultConfig.getRemoveDuplicateRule());
   }
 
   @Test
@@ -420,6 +497,14 @@ class MigrateAdaptersToUseScriptTest {
     AdapterDescription adapter = new AdapterDescription();
     adapter.setRules(new ArrayList<>(Collections.singletonList(rule)));
     // Initialize other mandatory structures if your migration touches them
+    adapter.setDataStream(new SpDataStream());
+    adapter.getDataStream().setEventSchema(new EventSchema());
+    return adapter;
+  }
+
+  private AdapterDescription createBaseAdapterWithoutRules() {
+    AdapterDescription adapter = new AdapterDescription();
+    adapter.setRules(new ArrayList<>());
     adapter.setDataStream(new SpDataStream());
     adapter.getDataStream().setEventSchema(new EventSchema());
     return adapter;

--- a/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
+++ b/streampipes-service-core/src/test/java/org/apache/streampipes/service/core/migrations/v099/MigrateAdaptersToUseScriptTest.java
@@ -88,6 +88,7 @@ class MigrateAdaptersToUseScriptTest {
   @Test
   void shouldExecute_ReturnsTrue_WhenAdapterHasLegacyRulesAndDefaultScript() {
     var adapter = createBaseAdapter(new RenameRuleDescription("old", "new"));
+    adapter.setTransformationConfig(TransformationConfig.withDefaultScript());
 
     when(mockStorage.findAll()).thenReturn(List.of(adapter));
 


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->
Previously the `MigrateAdaptersToUseScript` would migrate every adapter without script transformations enable because it checks if no script was set. This broke the `FileReplayAdapter`  by the deleting the inputs used to validate the timestamp.
This fixes it by migrating adapters without changing the transformation config inputs and outputs. Moreover it first checks to get new sample data from a file  if the the inputs are empty, before throwing an error. This make sure `FileReplayAdapters` still work after the migration.
It also prevents migrating a newly created adapter by making sure that the transformation config gets set when adding or updating an adapter

### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
