### PR TITLE
docs: route vulnerability reports to the ASF security team

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ extension runtime), the adversaries in and out of scope, and what StreamPipes
 upholds versus what it leaves to the operator.
 
 ### Step 2 — Read the security policy
-Read **[SECURITY.md](SECURITY.md)** for how to report (`security@streampipes.apache.org`).
+Read **[SECURITY.md](SECURITY.md)** for how to report (`security@apache.org`).
 
 ### Key scoping facts (see THREAT_MODEL.md)
 - The **streampipes-rest** HTTP/REST layer is the primary control boundary; the external-data  ingestion boundary is at the adapters. The broker, datastore, and extension-runtime services are assumed to run inside an operator-controlled perimeter. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,11 +19,11 @@
 
 ## Reporting a Vulnerability
 
-Please report suspected security vulnerabilities in Apache StreamPipes
-**privately** to the StreamPipes security list at
-`security@streampipes.apache.org`, following the [Apache Software Foundation security process](https://www.apache.org/security/).
-Do **not** open public GitHub issues or pull requests for security reports — a
-private report lets the issue be investigated and fixed before disclosure.
+Please report suspected security vulnerabilities in Apache StreamPipes **privately** to the ASF Security Team at [security@apache.org](mailto:security@apache.org?subject=%5BSECURITY%5D%20StreamPipes), following the [Apache Software Foundation security process](https://www.apache.org/security/).
+
+Please send one plain-text, unencrypted email per vulnerability, and describe the issue in the **message body** rather than as an image, HTML, or PDF attachment.
+
+Do **not** open public GitHub issues or pull requests for security reports, and do not disclose the issue publicly until the project has responded: a private report lets the issue be investigated and fixed before disclosure.
 
 ## Threat Model
 A threat model for Apache StreamPipes is maintained in


### PR DESCRIPTION
### Purpose

`SECURITY.md` currently asks reporters to send vulnerability reports to `security@streampipes.apache.org`. That mailing list does not exist and never did. Mail sent there is transparently Cc'd to `security@apache.org` (as all mail to `security@<project>.apache.org` is), so reports are not lost, but the reporter receives a bounce from the nonexistent list, which makes it look like the report went nowhere.

This PR:

- Points `SECURITY.md` (and the pointer in `AGENTS.md`) at the ASF Security Team address, [security@apache.org](mailto:security@apache.org?subject=%5BSECURITY%5D%20StreamPipes), with links to the [ASF security process](https://www.apache.org/security/).
- Restates the ASF submission conventions the security team expects: one plain-text, unencrypted email per vulnerability, described in the message body rather than as an image, HTML, or PDF attachment.
- Keeps the existing guidance not to open public issues or pull requests, and adds "do not disclose publicly until the project has responded".

Similar to apache/geaflow#828 and apache/spark#57844.

### Remarks

If the PMC prefers to receive reports directly instead of going through the ASF Security Team's initial triage, it can request an actual `security@streampipes.apache.org` list via an INFRA ticket, at which point this becomes a one-line change back.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
