### PR TITLE
feat; Show asset location in the asset overview

### DIFF
--- a/streampipes-model/src/main/java/org/apache/streampipes/model/assets/AssetSummaryDto.java
+++ b/streampipes-model/src/main/java/org/apache/streampipes/model/assets/AssetSummaryDto.java
@@ -21,5 +21,6 @@ package org.apache.streampipes.model.assets;
 public record AssetSummaryDto(String elementId,
                               String assetName,
                               String assetDescription,
+                              String siteId,
                               boolean removable) {
 }

--- a/streampipes-resource-management/src/main/java/org/apache/streampipes/resource/management/AssetResourceManager.java
+++ b/streampipes-resource-management/src/main/java/org/apache/streampipes/resource/management/AssetResourceManager.java
@@ -56,7 +56,7 @@ public class AssetResourceManager extends CrudResourceManager<SpAssetModel, IAss
         asset.getElementId(),
         asset.getAssetName(),
         asset.getAssetDescription(),
-        asset.getAssetSite() != null ? asset.getAssetSite().getSiteId() : null,
+        asset.getAssetSite() != null ? asset.getAssetSite().siteId() : null,
         asset.isRemovable()
     );
   }

--- a/streampipes-resource-management/src/main/java/org/apache/streampipes/resource/management/AssetResourceManager.java
+++ b/streampipes-resource-management/src/main/java/org/apache/streampipes/resource/management/AssetResourceManager.java
@@ -56,6 +56,7 @@ public class AssetResourceManager extends CrudResourceManager<SpAssetModel, IAss
         asset.getElementId(),
         asset.getAssetName(),
         asset.getAssetDescription(),
+        asset.getAssetSite() != null ? asset.getAssetSite().getSiteId() : null,
         asset.isRemovable()
     );
   }

--- a/ui/projects/streampipes/platform-services/src/lib/model/resource/resource-summary.model.ts
+++ b/ui/projects/streampipes/platform-services/src/lib/model/resource/resource-summary.model.ts
@@ -47,6 +47,7 @@ export interface AssetSummaryDto {
     elementId: string;
     assetName: string;
     assetDescription: string;
+    siteId?: string | null;
     removable: boolean;
 }
 

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.html
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.html
@@ -94,6 +94,14 @@
                             </div>
                         </td>
                     </ng-container>
+                    <ng-container matColumnDef="location">
+                        <th mat-header-cell mat-sort-header *matHeaderCellDef>
+                            {{ 'Location' | translate }}
+                        </th>
+                        <td mat-cell *matCellDef="let asset">
+                            {{ getLocationLabel(asset) }}
+                        </td>
+                    </ng-container>
                     <ng-template spTableActions let-element>
                         <button
                             mat-menu-item

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
@@ -16,7 +16,7 @@
  *
  */
 
-import { Component, inject, OnInit, ViewChild } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import {
     MatCell,
     MatCellDef,
@@ -26,7 +26,7 @@ import {
     MatTableDataSource,
 } from '@angular/material/table';
 import {
-    AssetSummaryDto,
+    AssetSiteDesc,
     AssetManagementService,
     SpAssetModel,
 } from '@streampipes/platform-services';
@@ -94,7 +94,7 @@ type ManageableAsset = SpAssetModel & {
         TranslatePipe,
     ],
 })
-export class SpAssetOverviewComponent implements OnInit {
+export class SpAssetOverviewComponent implements OnInit, OnDestroy {
     private assetService = inject(AssetManagementService);
     private breadcrumbService = inject(SpBreadcrumbService);
     private dialogService = inject(DialogService);
@@ -105,21 +105,23 @@ export class SpAssetOverviewComponent implements OnInit {
     private dialog = inject(MatDialog);
     private translateService = inject(TranslateService);
 
-    existingAssets: AssetSummaryDto[] = [];
-    filteredAssets: AssetSummaryDto[] = [];
+    existingAssets: SpAssetModel[] = [];
+    filteredAssets: SpAssetModel[] = [];
+    sitesById: Record<string, AssetSiteDesc> = {};
 
-    displayedColumns: string[] = ['assetName', 'actions'];
+    displayedColumns: string[] = ['assetName', 'location', 'actions'];
 
     @ViewChild(MatSort)
     sort: MatSort;
 
-    dataSource: MatTableDataSource<AssetSummaryDto> =
-        new MatTableDataSource<AssetSummaryDto>();
+    dataSource: MatTableDataSource<SpAssetModel> =
+        new MatTableDataSource<SpAssetModel>();
 
     hasWritePrivilege = false;
 
     assetFilter$: Subscription;
-    currentFilterIds = new Set<string>();
+    assetData$: Subscription;
+    currentFilterIds?: Set<string>;
 
     private assetFilterService = inject(SpAssetBrowserService);
 
@@ -129,6 +131,22 @@ export class SpAssetOverviewComponent implements OnInit {
         );
         this.breadcrumbService.updateBreadcrumb(
             this.breadcrumbService.getRootLink(SpAssetRoutes.BASE),
+        );
+
+        this.dataSource.sortingDataAccessor = (asset, column) => {
+            if (column === 'location') {
+                return this.getLocationLabel(asset);
+            }
+
+            return asset[column];
+        };
+
+        this.assetData$ = this.assetBrowserService.assetData$.subscribe(
+            assetData => {
+                this.sitesById = Object.fromEntries(
+                    (assetData?.sites ?? []).map(site => [site._id, site]),
+                );
+            },
         );
 
         this.loadAssets();
@@ -158,16 +176,23 @@ export class SpAssetOverviewComponent implements OnInit {
             });
     }
 
+    ngOnDestroy(): void {
+        this.assetFilter$?.unsubscribe();
+        this.assetData$?.unsubscribe();
+    }
+
     loadAssets(): void {
-        this.assetService.getAssetSummary().subscribe(result => {
-            this.existingAssets = result.resources.sort((a, b) =>
+        console.log('LOAD ASSET');
+        this.assetService.getAllAssets().subscribe(result => {
+            this.existingAssets = result.sort((a, b) =>
                 a.assetName.localeCompare(b.assetName),
             );
+            console.log(this.existingAssets);
             this.applyAssetFilters(this.currentFilterIds);
         });
     }
 
-    applyAssetFilters(elementIds: Set<string>): void {
+    applyAssetFilters(elementIds?: Set<string>): void {
         if (elementIds === undefined || elementIds.size === 0) {
             this.filteredAssets = this.existingAssets;
         } else {
@@ -177,6 +202,17 @@ export class SpAssetOverviewComponent implements OnInit {
         }
         this.dataSource.sort = this.sort;
         this.dataSource.data = this.filteredAssets;
+    }
+
+    getLocationLabel(asset: SpAssetModel): string {
+        const siteId = asset.assetSite?.siteId;
+        if (siteId) {
+            return (
+                this.sitesById[siteId]?.label ?? asset.assetSite?.area ?? '-'
+            );
+        }
+
+        return asset.assetSite?.area ?? '-';
     }
 
     createNewAsset() {
@@ -206,12 +242,12 @@ export class SpAssetOverviewComponent implements OnInit {
         );
     }
 
-    goToDetailsView(asset: AssetSummaryDto, editMode = false) {
+    goToDetailsView(asset: SpAssetModel, editMode = false) {
         const mode = editMode && this.hasWritePrivilege ? 'edit' : 'view';
         this.router.navigate(['assets', 'details', asset.elementId, mode]);
     }
 
-    deleteAsset(asset: AssetSummaryDto) {
+    deleteAsset(asset: SpAssetModel) {
         const dialogRef = this.dialog.open(ConfirmDialogComponent, {
             width: '500px',
             data: {
@@ -235,58 +271,53 @@ export class SpAssetOverviewComponent implements OnInit {
         });
     }
 
-    showManageDialog(assetSummary: AssetSummaryDto) {
-        this.assetService.getAsset(assetSummary.elementId).subscribe(asset => {
-            const resource: ManageableAsset = {
-                ...asset,
-                name: asset.assetName,
-                description: asset.assetDescription,
+    showManageDialog(asset: SpAssetModel) {
+        const resource: ManageableAsset = {
+            ...asset,
+            name: asset.assetName,
+            description: asset.assetDescription,
+        };
+        const resourceConfig: ObjectManageDialogResourceConfig<ManageableAsset> =
+            {
+                resourceLabel: 'Asset',
+                nameLabel: 'Asset name',
+                descriptionLabel: 'Asset description',
+                nameProperty: 'name',
+                showResourceFields: this.hasWritePrivilege,
+                showAssetLinking: false,
+                saveResource: this.hasWritePrivilege
+                    ? resource => {
+                          const { name, description, ...assetToSave } =
+                              resource;
+                          return this.assetService.updateAsset({
+                              ...assetToSave,
+                              assetName: name,
+                              assetDescription: description,
+                          });
+                      }
+                    : undefined,
             };
-            const resourceConfig: ObjectManageDialogResourceConfig<ManageableAsset> =
-                {
-                    resourceLabel: 'Asset',
-                    nameLabel: 'Asset name',
-                    descriptionLabel: 'Asset description',
-                    nameProperty: 'name',
-                    showResourceFields: this.hasWritePrivilege,
-                    showAssetLinking: false,
-                    saveResource: this.hasWritePrivilege
-                        ? resource => {
-                              const { name, description, ...assetToSave } =
-                                  resource;
-                              return this.assetService.updateAsset({
-                                  ...assetToSave,
-                                  assetName: name,
-                                  assetDescription: description,
-                              });
-                          }
-                        : undefined,
-                };
 
-            const dialogRef = this.dialogService.open(
-                ObjectManageDialogComponent,
-                {
-                    panelType: PanelType.SLIDE_IN_PANEL,
-                    title: this.translateService.instant('Manage'),
-                    width: '50vw',
-                    data: {
-                        objectInstanceId: resource.elementId,
-                        resource,
-                        saveMode: 'immediate',
-                        resourceConfig,
-                        headerTitle:
-                            this.translateService.instant('Manage Asset ') +
-                            resource.assetName,
-                    },
-                },
-            );
+        const dialogRef = this.dialogService.open(ObjectManageDialogComponent, {
+            panelType: PanelType.SLIDE_IN_PANEL,
+            title: this.translateService.instant('Manage'),
+            width: '50vw',
+            data: {
+                objectInstanceId: resource.elementId,
+                resource,
+                saveMode: 'immediate',
+                resourceConfig,
+                headerTitle:
+                    this.translateService.instant('Manage Asset ') +
+                    resource.assetName,
+            },
+        });
 
-            dialogRef.afterClosed().subscribe(refresh => {
-                if (refresh) {
-                    this.loadAssets();
-                    this.assetBrowserService.refreshBrowserAssetData();
-                }
-            });
+        dialogRef.afterClosed().subscribe(refresh => {
+            if (refresh) {
+                this.loadAssets();
+                this.assetBrowserService.refreshBrowserAssetData();
+            }
         });
     }
 }

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.ts
@@ -26,6 +26,7 @@ import {
     MatTableDataSource,
 } from '@angular/material/table';
 import {
+    AssetSummaryDto,
     AssetSiteDesc,
     AssetManagementService,
     SpAssetModel,
@@ -105,8 +106,8 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
     private dialog = inject(MatDialog);
     private translateService = inject(TranslateService);
 
-    existingAssets: SpAssetModel[] = [];
-    filteredAssets: SpAssetModel[] = [];
+    existingAssets: AssetSummaryDto[] = [];
+    filteredAssets: AssetSummaryDto[] = [];
     sitesById: Record<string, AssetSiteDesc> = {};
 
     displayedColumns: string[] = ['assetName', 'location', 'actions'];
@@ -114,8 +115,8 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
     @ViewChild(MatSort)
     sort: MatSort;
 
-    dataSource: MatTableDataSource<SpAssetModel> =
-        new MatTableDataSource<SpAssetModel>();
+    dataSource: MatTableDataSource<AssetSummaryDto> =
+        new MatTableDataSource<AssetSummaryDto>();
 
     hasWritePrivilege = false;
 
@@ -182,12 +183,10 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
     }
 
     loadAssets(): void {
-        console.log('LOAD ASSET');
-        this.assetService.getAllAssets().subscribe(result => {
-            this.existingAssets = result.sort((a, b) =>
+        this.assetService.getAssetSummary().subscribe(result => {
+            this.existingAssets = result.resources.sort((a, b) =>
                 a.assetName.localeCompare(b.assetName),
             );
-            console.log(this.existingAssets);
             this.applyAssetFilters(this.currentFilterIds);
         });
     }
@@ -204,15 +203,12 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
         this.dataSource.data = this.filteredAssets;
     }
 
-    getLocationLabel(asset: SpAssetModel): string {
-        const siteId = asset.assetSite?.siteId;
-        if (siteId) {
-            return (
-                this.sitesById[siteId]?.label ?? asset.assetSite?.area ?? '-'
-            );
+    getLocationLabel(asset: AssetSummaryDto): string {
+        if (asset.siteId) {
+            return this.sitesById[asset.siteId]?.label ?? '-';
         }
 
-        return asset.assetSite?.area ?? '-';
+        return '-';
     }
 
     createNewAsset() {
@@ -242,12 +238,12 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
         );
     }
 
-    goToDetailsView(asset: SpAssetModel, editMode = false) {
+    goToDetailsView(asset: AssetSummaryDto, editMode = false) {
         const mode = editMode && this.hasWritePrivilege ? 'edit' : 'view';
         this.router.navigate(['assets', 'details', asset.elementId, mode]);
     }
 
-    deleteAsset(asset: SpAssetModel) {
+    deleteAsset(asset: AssetSummaryDto) {
         const dialogRef = this.dialog.open(ConfirmDialogComponent, {
             width: '500px',
             data: {
@@ -271,53 +267,58 @@ export class SpAssetOverviewComponent implements OnInit, OnDestroy {
         });
     }
 
-    showManageDialog(asset: SpAssetModel) {
-        const resource: ManageableAsset = {
-            ...asset,
-            name: asset.assetName,
-            description: asset.assetDescription,
-        };
-        const resourceConfig: ObjectManageDialogResourceConfig<ManageableAsset> =
-            {
-                resourceLabel: 'Asset',
-                nameLabel: 'Asset name',
-                descriptionLabel: 'Asset description',
-                nameProperty: 'name',
-                showResourceFields: this.hasWritePrivilege,
-                showAssetLinking: false,
-                saveResource: this.hasWritePrivilege
-                    ? resource => {
-                          const { name, description, ...assetToSave } =
-                              resource;
-                          return this.assetService.updateAsset({
-                              ...assetToSave,
-                              assetName: name,
-                              assetDescription: description,
-                          });
-                      }
-                    : undefined,
+    showManageDialog(assetSummary: AssetSummaryDto) {
+        this.assetService.getAsset(assetSummary.elementId).subscribe(asset => {
+            const resource: ManageableAsset = {
+                ...asset,
+                name: asset.assetName,
+                description: asset.assetDescription,
             };
+            const resourceConfig: ObjectManageDialogResourceConfig<ManageableAsset> =
+                {
+                    resourceLabel: 'Asset',
+                    nameLabel: 'Asset name',
+                    descriptionLabel: 'Asset description',
+                    nameProperty: 'name',
+                    showResourceFields: this.hasWritePrivilege,
+                    showAssetLinking: false,
+                    saveResource: this.hasWritePrivilege
+                        ? resource => {
+                              const { name, description, ...assetToSave } =
+                                  resource;
+                              return this.assetService.updateAsset({
+                                  ...assetToSave,
+                                  assetName: name,
+                                  assetDescription: description,
+                              });
+                          }
+                        : undefined,
+                };
 
-        const dialogRef = this.dialogService.open(ObjectManageDialogComponent, {
-            panelType: PanelType.SLIDE_IN_PANEL,
-            title: this.translateService.instant('Manage'),
-            width: '50vw',
-            data: {
-                objectInstanceId: resource.elementId,
-                resource,
-                saveMode: 'immediate',
-                resourceConfig,
-                headerTitle:
-                    this.translateService.instant('Manage Asset ') +
-                    resource.assetName,
-            },
-        });
+            const dialogRef = this.dialogService.open(
+                ObjectManageDialogComponent,
+                {
+                    panelType: PanelType.SLIDE_IN_PANEL,
+                    title: this.translateService.instant('Manage'),
+                    width: '50vw',
+                    data: {
+                        objectInstanceId: resource.elementId,
+                        resource,
+                        saveMode: 'immediate',
+                        resourceConfig,
+                        headerTitle:
+                            this.translateService.instant('Manage Asset ') +
+                            resource.assetName,
+                    },
+                },
+            );
 
-        dialogRef.afterClosed().subscribe(refresh => {
-            if (refresh) {
-                this.loadAssets();
-                this.assetBrowserService.refreshBrowserAssetData();
-            }
+            dialogRef.afterClosed().subscribe(refresh => {
+                if (refresh) {
+                    this.loadAssets();
+                    this.assetBrowserService.refreshBrowserAssetData();
+                }
+            });
         });
     }
 }


### PR DESCRIPTION
Resolves #4816 . Added asset location to asset overview.
As the site is a significant part of an asset, I added the siteId to the asset summary.


<img width="1335" height="324" alt="image" src="https://github.com/user-attachments/assets/7bc57e6d-ae20-4dbe-ad33-ad8e5f113b28" />



PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
