### PR TITLE
4835 filter is cashed between users

### DIFF
--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
@@ -17,7 +17,7 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, zip } from 'rxjs';
+import { BehaviorSubject, filter, skip, zip } from 'rxjs';
 import {
     AssetConstants,
     AssetManagementService,
@@ -34,6 +34,7 @@ import {
     FilterResult,
 } from './asset-browser.model';
 import { LocalStorageService } from '../../services/local-storage-settings.service';
+import { CurrentUserService } from '../../services/current-user.service';
 
 @Injectable({ providedIn: 'root' })
 export class SpAssetBrowserService {
@@ -54,9 +55,16 @@ export class SpAssetBrowserService {
     private typeService = inject(Isa95TypeService);
     private assetService = inject(AssetManagementService);
     private localStorageService = inject(LocalStorageService);
+    private currentUserService = inject(CurrentUserService);
 
     constructor() {
         this.listenForDataRefresh();
+        this.currentUserService.isLoggedIn$
+            .pipe(
+                skip(1),
+                filter(isLoggedIn => !isLoggedIn),
+            )
+            .subscribe(() => this.resetState());
         this.loadAssetData();
     }
 
@@ -134,6 +142,17 @@ export class SpAssetBrowserService {
     resetFilters(): void {
         this.assetData$.next(this.loadedAssetData);
         this.reloadFilters();
+    }
+
+    private resetState(): void {
+        this.loadedAssetData = undefined;
+        this.activeAssetLink = undefined;
+        this.assetData$.next(undefined);
+        this.filter$.next(undefined);
+        this.currentAssetFilter$.next({
+            filterActive: false,
+            filterDisabled: true,
+        });
     }
 
     applyFilters(filter: AssetFilter) {

--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser.service.ts
@@ -17,7 +17,7 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, filter, skip, zip } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, skip, zip } from 'rxjs';
 import {
     AssetConstants,
     AssetManagementService,
@@ -60,11 +60,14 @@ export class SpAssetBrowserService {
     constructor() {
         this.listenForDataRefresh();
         this.currentUserService.isLoggedIn$
-            .pipe(
-                skip(1),
-                filter(isLoggedIn => !isLoggedIn),
-            )
-            .subscribe(() => this.resetState());
+            .pipe(skip(1), distinctUntilChanged())
+            .subscribe(isLoggedIn => {
+                if (isLoggedIn) {
+                    this.loadAssetData();
+                } else {
+                    this.resetState();
+                }
+            });
         this.loadAssetData();
     }
 
@@ -146,7 +149,6 @@ export class SpAssetBrowserService {
 
     private resetState(): void {
         this.loadedAssetData = undefined;
-        this.activeAssetLink = undefined;
         this.assetData$.next(undefined);
         this.filter$.next(undefined);
         this.currentAssetFilter$.next({


### PR DESCRIPTION
Reset the shared asset-browser state on logout so a newly logged-in user no longer inherits the previous user’s active filters or toolbar content. Refresh the asset-browser automatically on login, removing the need for a manual page refresh to restore the filter options.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
