### PR TITLE
Show the certificate subject in the certificate list

### DIFF
--- a/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-label/certificate-label.component.html
+++ b/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-label/certificate-label.component.html
@@ -18,8 +18,13 @@
 
 <div fxLayout="column" class="pt-sm pb-sm">
     <span class="text-sm">
-        {{ certificate.issuerDn }}
+        {{ certificate.subjectDn }}
     </span>
+    @if (applicationUri) {
+        <span class="text-sm">
+            {{ applicationUri }}
+        </span>
+    }
     <div fxLayout="row wrap" class="mt-sm">
         @for (dnsName of dnsNames; track $index) {
             <sp-label

--- a/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-label/certificate-label.component.ts
+++ b/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-label/certificate-label.component.ts
@@ -31,11 +31,14 @@ export class CertificateLabelComponent implements OnInit {
     certificate: Certificate;
 
     dnsNames: string[] = [];
+    applicationUri: string;
 
     ngOnInit(): void {
         this.dnsNames = this.certificate.subjectAlternativeNames.filter(san =>
             san.startsWith('DNS'),
         );
-        console.log(this.dnsNames);
+        this.applicationUri = this.certificate.subjectAlternativeNames.find(
+            san => san.startsWith('URI'),
+        );
     }
 }


### PR DESCRIPTION
Closes #4841.

`certificate-label.component.html` rendered `certificate.issuerDn`, so every certificate signed by the same intermediate or root CA showed the same string and there was no way to tell two servers apart without opening each one.

It now shows `subjectDn`, and the OPC UA ApplicationUri underneath it, taken from the `URI` entry of `subjectAlternativeNames` as you suggested, since that is what an operator actually matches a server on. The DNS badges below are untouched. `subjectDn` and `subjectAlternativeNames` are both already on the `Certificate` model (`streampipes-model.ts:721-738`), so nothing needed to change on the API side.

One thing outside the strict scope: `ngOnInit` had a leftover `console.log(this.dnsNames)` sitting in the lines I was editing, so it is gone too. Happy to put it back if you would rather keep this to the reported change.

On verification, so the claim is not larger than what I did: this is a template and component change and I have not run the UI. I checked the field names against the generated model and ran the repo's own prettier config (3.7.4, `ui/.prettierrc.json`) over both files, which reports "All matched files use Prettier code style". I have not run `ng lint` or built the frontend, so CI is the real check there.
