### PR TITLE
docs(#4858): fix broken links in client, connector and installer docs

### DIFF
--- a/installer/compose/README.md
+++ b/installer/compose/README.md
@@ -29,7 +29,7 @@ StreamPipes Compose is a simple collection of user-friendly `docker-compose` fil
 ```bash
 docker-compose up -d
 ```
-Go to http://localhost to finish the installation in the browser. Once finished, switch to the pipeline editor and start the interactive tour or check the [online tour](https://streampipes.apache.org/docs/user-guide-tour/) to learn how to create your first pipeline!
+Go to http://localhost to finish the installation in the browser. Once finished, switch to the pipeline editor and start the interactive tour or check the [online tour](https://streampipes.apache.org/docs/user-guide-introduction/) to learn how to create your first pipeline!
 
 ## Prerequisite
 * Docker >= 17.06.0

--- a/installer/scripts/epsg/Readme.md
+++ b/installer/scripts/epsg/Readme.md
@@ -92,7 +92,7 @@ Unzip the folder and replace files
 in the `streampipes/installer/scripts/epsg` folder.
 
 For indexing the imported data and get better performance, go to 
-<a href="https://github.com/apache/sis/blob/master/core/sis-referencing/src/main/resources/org/apache/sis/referencing/factory/sql/EPSG_Finish.sql" target="_blank">this file</a>
+<a href="https://github.com/apache/sis/blob/main/optional/src/org.apache.sis.referencing.epsg/main/org/apache/sis/referencing/factory/sql/epsg/Finish.sql" target="_blank">this file</a>
 and replace it with the
 * EPSG_FINISH.sql
 

--- a/streampipes-client-go/docs/content/en/docs/getting-started/first-steps.md
+++ b/streampipes-client-go/docs/content/en/docs/getting-started/first-steps.md
@@ -44,7 +44,7 @@ If Go is not installed, you can download and install it from the [official Go we
 
 Access to a running instance of Apache StreamPipes is required.
 
-If you do not have it set up yet, please refer to the [Apache StreamPipes installation guide](https://streampipes.apache.org/docs/try-installation/) for detailed instructions on how to install and configure it on your system.
+If you do not have it set up yet, please refer to the [Apache StreamPipes installation guide](https://streampipes.apache.org/docs/quick-start-guide/) for detailed instructions on how to install and configure it on your system.
 
 Once these requirements are met, you are ready to proceed with the next step Quickstart in the setup process!
 

--- a/streampipes-client-python/docs/getting-started/first-steps.md
+++ b/streampipes-client-python/docs/getting-started/first-steps.md
@@ -48,7 +48,7 @@ CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
 ...            ...       ...       ...       ...       ...       ...
 ```
 Otherwise, you need to start docker first.
-Please read the full guide on how to start StreamPipes with `docker compose` [here](https://streampipes.apache.org/docs/deploy-docker/).
+Please read the full guide on how to start StreamPipes with `docker compose` [here](https://streampipes.apache.org/docs/configure-operate-deployment/).
 
 #### Setup StreamPipes with NATS as message broker
 The following shows how you can set up a StreamPipes instance that uses [NATS](https://docs.nats.io/) as messaging layer.

--- a/streampipes-extensions/streampipes-connectors-plc/src/main/resources/org.apache.streampipes.connect.iiot.adapters.plc4x.generic/documentation.md
+++ b/streampipes-extensions/streampipes-connectors-plc/src/main/resources/org.apache.streampipes.connect.iiot.adapters.plc4x.generic/documentation.md
@@ -72,7 +72,7 @@ PROTOCOL_METADATA_ADVANCED
 
 ### Tags
 
-The syntax to define tags is based on the PLC4X syntax, see https://plc4x.apache.org/users/protocols/s7.html.
+The syntax to define tags is based on the PLC4X syntax, see https://plc4x.apache.org/plc4x/latest/users/protocols/s7.html.
 Address Pattern:
 
 ```

--- a/streampipes-extensions/streampipes-connectors-plc/src/main/resources/org.apache.streampipes.connect.iiot.adapters.plc4x.s7/documentation.md
+++ b/streampipes-extensions/streampipes-connectors-plc/src/main/resources/org.apache.streampipes.connect.iiot.adapters.plc4x.s7/documentation.md
@@ -54,7 +54,7 @@ Additional configs are separated by `&`.
 
 Example address: `192.68.34.56?remote-rack=0&remote-slot=3&controller-type=S7_400`
 
-See the <a href="https://plc4x.apache.org/users/protocols/s7.html">Apache PLC4X documentation</a> for more information.
+See the <a href="https://plc4x.apache.org/plc4x/latest/users/protocols/s7.html">Apache PLC4X documentation</a> for more information.
 
 ### Polling Interval
 


### PR DESCRIPTION
Closes #4858.

## Purpose

Fixes six dead documentation links. Every replacement was resolved with `curl -L`; the originals were re-checked serially with a browser user agent so these are not rate-limiting artefacts.

**streampipes.apache.org pages that moved** — the old paths exist only under versioned prefixes and 404 unversioned:

| File | old → new | old | new |
| --- | --- | --- | --- |
| `streampipes-client-go/.../first-steps.md:47` | `try-installation/` → `quick-start-guide/` | 404 | 200 |
| `streampipes-client-python/.../first-steps.md:51` | `deploy-docker/` → `configure-operate-deployment/` | 404 | 200 |
| `installer/compose/README.md:32` | `user-guide-tour/` → `user-guide-introduction/` | 404 | 200 |

**Apache PLC4X moved to an Antora layout** — `/users/...` is gone, pages now live under `/plc4x/latest/users/...`:

- `.../adapters.plc4x.s7/documentation.md:57`
- `.../adapters.plc4x.generic/documentation.md:75`

Both linked `https://plc4x.apache.org/users/protocols/s7.html` (404); now `https://plc4x.apache.org/plc4x/latest/users/protocols/s7.html` (200). These are adapter descriptions rendered in the StreamPipes UI, so they are user-facing.

**apache/sis renamed the file and its default branch** — `installer/scripts/epsg/Readme.md:95` linked `blob/master/core/sis-referencing/.../EPSG_Finish.sql` (404). `apache/sis` now defaults to `main` and the file is at `optional/src/org.apache.sis.referencing.epsg/main/org/apache/sis/referencing/factory/sql/epsg/Finish.sql` — confirmed through the GitHub trees API, including the rename from `EPSG_Finish.sql` to `Finish.sql`.

## Scope

Links only — no prose, no code, no behaviour change.

I checked that nothing else was caught by the same patterns: the `github.com/apache/streampipes/streampipes-client-go` strings in `quickstart.md`, `ManageAdapter.md` and `ManagePipeline.md` are correct Go import paths and are untouched.

Not included here: the Go client's `first-steps.md` also documents a `go get` command that cannot work. That is a command-syntax problem rather than a link problem, so I will raise it separately rather than mixing it in.

_Disclosure: prepared with AI assistance; every URL was verified manually._
