### PR TITLE
docs: fix go get command in Go client getting started guide

### DIFF
--- a/streampipes-client-go/docs/content/en/docs/getting-started/first-steps.md
+++ b/streampipes-client-go/docs/content/en/docs/getting-started/first-steps.md
@@ -53,8 +53,5 @@ Once these requirements are met, you are ready to proceed with the next step Qui
 The StreamPipes Go library is meant to work with Go 1.21 and above. You can install the latest development version from GitHub, as so:
 
 ```shell
-go get https://github.com/apache/streampipes
-// if you want to have the current development state you can also execute
-go get https://github.com/apache/streampipes/streampipes-client-go
-// the corresponding documentation can be found here: https://streampipes.apache.org/docs/docs/python/dev/
+go get github.com/apache/streampipes/streampipes-client-go
 ```


### PR DESCRIPTION
## Purpose

The install snippet in the Go client's getting-started guide cannot be run as written.

```shell
go get https://github.com/apache/streampipes
// if you want to have the current development state you can also execute
go get https://github.com/apache/streampipes/streampipes-client-go
// the corresponding documentation can be found here: https://streampipes.apache.org/docs/docs/python/dev/
```

Four problems:

1. **`go get` does not accept a URL scheme.** It takes a module path, so `go get https://...` fails.
2. **The first path is not a Go module.** `streampipes-client-go/go.mod` declares `module github.com/apache/streampipes/streampipes-client-go`; the repository root has no `go.mod`, so `github.com/apache/streampipes` cannot be fetched as a module at all.
3. **`//` is not a shell comment.** Inside a ```` ```shell ```` block the comment character is `#`, so those lines would be executed rather than ignored.
4. **The link points at the Python documentation.** `https://streampipes.apache.org/docs/docs/python/dev/` is the Python client's page, in the Go client's guide.

Since the two `go get` lines resolve to the same module — and only the second one is a valid module path — this replaces the whole block with the single command that works:

```shell
go get github.com/apache/streampipes/streampipes-client-go
```

I dropped the documentation comment rather than repointing it, because the reader is already inside the Go documentation. If you'd prefer a link to a specific Go client page, tell me the URL and I'll add it back.

## How I checked

The module path was read from `streampipes-client-go/go.mod` on `dev`, and cross-checked against the import paths already used in `quickstart.md`, `ManageAdapter.md` and `ManagePipeline.md`, which all use `github.com/apache/streampipes/streampipes-client-go/...`.

Documentation only — no code changes. This is deliberately kept separate from #4859, which fixes broken links; this one is a command-syntax problem.

_Disclosure: prepared with AI assistance; the module path was verified against `go.mod`._
