### PR TITLE
fix: support Commons IO 2.22 BOM streams

### DIFF
--- a/streampipes-pipeline-management/src/main/java/org/apache/streampipes/manager/file/FileManager.java
+++ b/streampipes-pipeline-management/src/main/java/org/apache/streampipes/manager/file/FileManager.java
@@ -101,7 +101,7 @@ public class FileManager {
 
   private InputStream validateFileNameAndCleanFile(String filename,
                                                   String filetype,
-                                                  InputStream fileInputStream) {
+                                                  InputStream fileInputStream) throws IOException {
     if (!validateFileType(filename)) {
       throw new IllegalArgumentException("Filetype for file %s not allowed".formatted(filename));
     }
@@ -116,9 +116,11 @@ public class FileManager {
    * @param filetype file of type
    * @return input stream without BOM
    */
-  protected InputStream cleanFile(InputStream fileInputStream, String filetype) {
+  protected InputStream cleanFile(InputStream fileInputStream, String filetype) throws IOException {
     if (Filetypes.CSV.getFileExtensions().contains(filetype.toLowerCase())) {
-      fileInputStream = new BOMInputStream(fileInputStream);
+      fileInputStream = BOMInputStream.builder()
+          .setInputStream(fileInputStream)
+          .get();
     }
 
     return fileInputStream;


### PR DESCRIPTION
### Purpose

Completes the Commons IO 2.22 upgrade from [#4625](https://github.com/apache/streampipes/pull/4625).

Commons IO 2.22 makes `BOMInputStream` construction report `IOException`. This replaces the deprecated constructor with the builder API and propagates that checked failure through the existing file-storage boundary, which already reports `IOException`.

### Remarks

- Exact source revision: `9662f633d73660353bd48317e7b7ffb39769d3d7`
- Scope: one production file; no dependency or unrelated changes
- Verification: `mvn -pl streampipes-pipeline-management -am test` on JDK 25 / Maven 3.9.16
  - all 25 reactor modules succeeded
  - 95 tests, 0 failures or errors
  - Checkstyle and dependency convergence passed
- The build itself completed successfully; only the subsequent Develocity scan publication could not reach its server.

PR introduces breaking changes: no

PR introduces deprecations: no

### AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, `jaipilot-review-diff`, and `jaipilot-remote-java`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
