### PR TITLE
fix(connect): support configurable decimal separator in CSV parser

### DIFF
--- a/streampipes-connect-shared/src/main/java/org/apache/streampipes/connect/shared/DatatypeUtils.java
+++ b/streampipes-connect-shared/src/main/java/org/apache/streampipes/connect/shared/DatatypeUtils.java
@@ -31,6 +31,12 @@ public class DatatypeUtils {
   private static final Logger LOG = LoggerFactory.getLogger(DatatypeUtils.class);
 
   /**
+   * The decimal separator assumed by {@link Double#parseDouble(String)} and
+   * {@link org.apache.commons.lang3.math.NumberUtils#isParsable(String)}.
+   */
+  public static final char DEFAULT_DECIMAL_SEPARATOR = '.';
+
+  /**
    * Converts the given value to a specified XSD datatype.
    * This method attempts to convert the input value to the target datatype specified by the XSD string.
    * It supports conversion to string, double, float, boolean, integer, and long types.
@@ -53,6 +59,27 @@ public class DatatypeUtils {
                                     Object value,
                                     String targetDatatypeXsd,
                                     AtomicBoolean loggedConversionError) {
+    return convertValue(adapterName, value, targetDatatypeXsd, DEFAULT_DECIMAL_SEPARATOR, loggedConversionError);
+  }
+
+  /**
+   * Converts the given value to a specified XSD datatype using the provided decimal separator.
+   * When the input is a string representing a floating point number that uses a decimal separator
+   * other than {@code '.'} (e.g. the {@code ','} common in many European locales), the separator
+   * is normalized before parsing so that the value is treated as numeric rather than as a string.
+   *
+   * @param adapterName The adapter whose event value should be converted.
+   * @param value The value to be converted.
+   * @param targetDatatypeXsd The target XSD datatype as a string.
+   * @param decimalSeparator The decimal separator used in string representations of numbers.
+   * @param loggedConversionError Guard that ensures a conversion error is logged at warn level only once.
+   * @return The converted value, or the original value if conversion fails.
+   */
+  public static Object convertValue(String adapterName,
+                                    Object value,
+                                    String targetDatatypeXsd,
+                                    char decimalSeparator,
+                                    AtomicBoolean loggedConversionError) {
     if (value == null) {
       return null;
     }
@@ -74,7 +101,7 @@ public class DatatypeUtils {
     }
 
     try {
-      return convertString(String.valueOf(value), targetDatatypeXsd);
+      return convertString(normalizeDecimalSeparator(String.valueOf(value), decimalSeparator), targetDatatypeXsd);
     } catch (NumberFormatException e) {
       logConversionError(adapterName, value, targetDatatypeXsd, loggedConversionError);
       return value;
@@ -149,7 +176,13 @@ public class DatatypeUtils {
 
   public static String getXsdDatatype(String value,
                                       boolean preferFloat) {
-    var clazz = getTypeClass(value, preferFloat);
+    return getXsdDatatype(value, preferFloat, DEFAULT_DECIMAL_SEPARATOR);
+  }
+
+  public static String getXsdDatatype(String value,
+                                      boolean preferFloat,
+                                      char decimalSeparator) {
+    var clazz = getTypeClass(value, preferFloat, decimalSeparator);
     if (clazz.equals(Integer.class)) {
       return XSD.INTEGER.toString();
     } else if (clazz.equals(Long.class)) {
@@ -167,10 +200,19 @@ public class DatatypeUtils {
 
   public static Class<?> getTypeClass(String value,
                                       boolean preferFloatingPointNumber) {
+    return getTypeClass(value, preferFloatingPointNumber, DEFAULT_DECIMAL_SEPARATOR);
+  }
+
+  public static Class<?> getTypeClass(String value,
+                                      boolean preferFloatingPointNumber,
+                                      char decimalSeparator) {
     var targetClass = String.class;
     if (value == null) {
       return targetClass;
     }
+
+    var originalValue = value;
+    value = normalizeDecimalSeparator(value, decimalSeparator);
 
     if (NumberUtils.isParsable(value)) {
       Class<?> numberClass;
@@ -204,11 +246,48 @@ public class DatatypeUtils {
 
     }
 
-    if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+    if (originalValue.equalsIgnoreCase("true") || originalValue.equalsIgnoreCase("false")) {
       return Boolean.class;
     }
 
     return targetClass;
+  }
+
+  /**
+   * Normalizes the decimal separator of a numeric string representation to {@code '.'} so that it
+   * can be parsed by {@link Double#parseDouble(String)} and recognized by
+   * {@link org.apache.commons.lang3.math.NumberUtils#isParsable(String)}.
+   *
+   * <p>Normalization is only applied when the provided separator is not the default {@code '.'}.
+   * To avoid misinterpreting the separator when it is also used as a thousands/grouping separator
+   * (e.g. {@code "1,000"}), normalization is skipped when the value contains more than one
+   * occurrence of the separator.</p>
+   *
+   * @param value the raw string value
+   * @param decimalSeparator the decimal separator used in the value
+   * @return the value with its decimal separator replaced by {@code '.'}, or the original value
+   *         when no normalization is applicable
+   */
+  private static String normalizeDecimalSeparator(String value,
+                                                  char decimalSeparator) {
+    if (value == null || decimalSeparator == DEFAULT_DECIMAL_SEPARATOR) {
+      return value;
+    }
+
+    // Do not normalize when the separator appears more than once, since it is then ambiguous
+    // (e.g. used as a grouping separator) and normalization could corrupt the value.
+    var firstIndex = value.indexOf(decimalSeparator);
+    if (firstIndex < 0 || firstIndex != value.lastIndexOf(decimalSeparator)) {
+      return value;
+    }
+
+    // Only normalize genuine numeric candidates; a value already containing '.' is not a
+    // single-separator decimal in the target locale and must be left untouched.
+    if (value.indexOf(DEFAULT_DECIMAL_SEPARATOR) >= 0) {
+      return value;
+    }
+
+    return value.replace(decimalSeparator, DEFAULT_DECIMAL_SEPARATOR);
   }
 
 }

--- a/streampipes-connect-shared/src/main/java/org/apache/streampipes/connect/shared/DatatypeUtils.java
+++ b/streampipes-connect-shared/src/main/java/org/apache/streampipes/connect/shared/DatatypeUtils.java
@@ -64,9 +64,10 @@ public class DatatypeUtils {
 
   /**
    * Converts the given value to a specified XSD datatype using the provided decimal separator.
-   * When the input is a string representing a floating point number that uses a decimal separator
-   * other than {@code '.'} (e.g. the {@code ','} common in many European locales), the separator
-   * is normalized before parsing so that the value is treated as numeric rather than as a string.
+   * When a non-default decimal separator is configured (e.g. the {@code ','} common in many
+   * European locales), it is normalized to {@code '.'} before parsing. Values that use a different
+   * separator than the configured one (e.g. {@code "100.000"} when {@code ','} is selected) are
+   * treated as strings and left unchanged.
    *
    * @param adapterName The adapter whose event value should be converted.
    * @param value The value to be converted.
@@ -100,8 +101,14 @@ public class DatatypeUtils {
       return value;
     }
 
+    var normalized = normalizeDecimalSeparator(String.valueOf(value), decimalSeparator);
+    if (normalized == null) {
+      // The value is not a valid number under the configured decimal separator; keep it unchanged.
+      return value;
+    }
+
     try {
-      return convertString(normalizeDecimalSeparator(String.valueOf(value), decimalSeparator), targetDatatypeXsd);
+      return convertString(normalized, targetDatatypeXsd);
     } catch (NumberFormatException e) {
       logConversionError(adapterName, value, targetDatatypeXsd, loggedConversionError);
       return value;
@@ -212,9 +219,11 @@ public class DatatypeUtils {
     }
 
     var originalValue = value;
+    // Returns null when the value is not a valid number under the configured decimal separator
+    // (e.g. it uses a different separator), in which case it must be treated as a string.
     value = normalizeDecimalSeparator(value, decimalSeparator);
 
-    if (NumberUtils.isParsable(value)) {
+    if (value != null && NumberUtils.isParsable(value)) {
       Class<?> numberClass;
       try {
         long longValue = Long.parseLong(value);
@@ -264,27 +273,39 @@ public class DatatypeUtils {
    * occurrence of the separator.</p>
    *
    * @param value the raw string value
-   * @param decimalSeparator the decimal separator used in the value
-   * @return the value with its decimal separator replaced by {@code '.'}, or the original value
-   *         when no normalization is applicable
+   * @param decimalSeparator the decimal separator configured for the data source
+   * @return a string parseable with {@code '.'} as decimal separator, or {@code null} if the value
+   *         must not be interpreted as a number under the configured separator
    */
   private static String normalizeDecimalSeparator(String value,
                                                   char decimalSeparator) {
-    if (value == null || decimalSeparator == DEFAULT_DECIMAL_SEPARATOR) {
+    if (value == null) {
+      return null;
+    }
+
+    // Default separator: keep the historical behavior (values are parsed as-is).
+    if (decimalSeparator == DEFAULT_DECIMAL_SEPARATOR) {
       return value;
     }
 
-    // Do not normalize when the separator appears more than once, since it is then ambiguous
-    // (e.g. used as a grouping separator) and normalization could corrupt the value.
-    var firstIndex = value.indexOf(decimalSeparator);
-    if (firstIndex < 0 || firstIndex != value.lastIndexOf(decimalSeparator)) {
-      return value;
-    }
-
-    // Only normalize genuine numeric candidates; a value already containing '.' is not a
-    // single-separator decimal in the target locale and must be left untouched.
+    // A non-default separator is configured. A value that uses the default '.' is therefore not a
+    // valid number in the configured locale and must stay a string (e.g. "100.000" with ',').
     if (value.indexOf(DEFAULT_DECIMAL_SEPARATOR) >= 0) {
+      return null;
+    }
+
+    var firstIndex = value.indexOf(decimalSeparator);
+
+    // No configured separator present: it is a plain integer-like token (e.g. "42") and can be
+    // parsed as-is.
+    if (firstIndex < 0) {
       return value;
+    }
+
+    // The configured separator appears more than once, so it is ambiguous (e.g. a grouping
+    // separator like "1,000,000"); do not treat it as a single decimal number.
+    if (firstIndex != value.lastIndexOf(decimalSeparator)) {
+      return null;
     }
 
     return value.replace(decimalSeparator, DEFAULT_DECIMAL_SEPARATOR);

--- a/streampipes-connect-shared/src/test/java/org/apache/streampipes/connect/shared/preprocessing/transform/DatatypeUtilsTest.java
+++ b/streampipes-connect-shared/src/test/java/org/apache/streampipes/connect/shared/preprocessing/transform/DatatypeUtilsTest.java
@@ -256,4 +256,65 @@ public class DatatypeUtilsTest {
     assertEquals(String.class, result);
   }
 
+  // --- Tests for decimal separator support (issue #530) ---
+
+  @Test
+  public void getTypeClass_CommaDecimalSeparatorIsNumeric() {
+    var result = DatatypeUtils.getTypeClass("3,14", false, ',');
+    assertEquals(Float.class, result);
+  }
+
+  @Test
+  public void getTypeClass_CommaDecimalSeparatorWithPreferFloat() {
+    var result = DatatypeUtils.getTypeClass("3,14", true, ',');
+    assertEquals(Float.class, result);
+  }
+
+  @Test
+  public void getTypeClass_CommaSeparatorLeavesDotValueParsable() {
+    // Behavior is additive: configuring ',' as the decimal separator adds recognition of
+    // comma-decimals without rejecting values that are already valid with the default '.' separator.
+    var result = DatatypeUtils.getTypeClass("3.14", false, ',');
+    assertEquals(Float.class, result);
+  }
+
+  @Test
+  public void getTypeClass_CommaSeparatorMultipleCommasStaysString() {
+    // Ambiguous grouping usage (e.g. thousands separator) must not be normalized.
+    var result = DatatypeUtils.getTypeClass("1,000,000", false, ',');
+    assertEquals(String.class, result);
+  }
+
+  @Test
+  public void getTypeClass_DefaultSeparatorUnaffectedByCommaValue() {
+    var result = DatatypeUtils.getTypeClass("3,14", false);
+    assertEquals(String.class, result);
+  }
+
+  @Test
+  public void getXsdDatatype_CommaDecimalSeparatorReturnsFloat() {
+    var result = DatatypeUtils.getXsdDatatype("2,5", false, ',');
+    assertEquals(XSD.FLOAT.toString(), result);
+  }
+
+  @Test
+  public void convertValue_CommaSeparatorStringToFloat() {
+    var actualValue = DatatypeUtils.convertValue(
+        TEST_ADAPTER_NAME, "123,45", XSD.FLOAT.toString(), ',', new java.util.concurrent.atomic.AtomicBoolean(false));
+    assertEquals(123.45f, actualValue);
+  }
+
+  @Test
+  public void convertValue_CommaSeparatorStringToDouble() {
+    var actualValue = DatatypeUtils.convertValue(
+        TEST_ADAPTER_NAME, "123,45", XSD.DOUBLE.toString(), ',', new java.util.concurrent.atomic.AtomicBoolean(false));
+    assertEquals(123.45d, actualValue);
+  }
+
+  @Test
+  public void convertValue_DefaultSeparatorDotStillWorks() {
+    var actualValue = DatatypeUtils.convertValue(TEST_ADAPTER_NAME, "123.45", XSD.FLOAT.toString());
+    assertEquals(123.45f, actualValue);
+  }
+
 }

--- a/streampipes-connect-shared/src/test/java/org/apache/streampipes/connect/shared/preprocessing/transform/DatatypeUtilsTest.java
+++ b/streampipes-connect-shared/src/test/java/org/apache/streampipes/connect/shared/preprocessing/transform/DatatypeUtilsTest.java
@@ -271,11 +271,25 @@ public class DatatypeUtilsTest {
   }
 
   @Test
-  public void getTypeClass_CommaSeparatorLeavesDotValueParsable() {
-    // Behavior is additive: configuring ',' as the decimal separator adds recognition of
-    // comma-decimals without rejecting values that are already valid with the default '.' separator.
+  public void getTypeClass_CommaSeparatorTreatsDotValueAsString() {
+    // Strict behavior: when ',' is the configured decimal separator, a value using '.' is not a
+    // valid number in that locale and must stay a string.
     var result = DatatypeUtils.getTypeClass("3.14", false, ',');
-    assertEquals(Float.class, result);
+    assertEquals(String.class, result);
+  }
+
+  @Test
+  public void getTypeClass_CommaSeparatorDotGroupingStaysString() {
+    // Regression for review of PR #4878: "100.000" must not be parsed as float when ',' is selected.
+    var result = DatatypeUtils.getTypeClass("100.000", false, ',');
+    assertEquals(String.class, result);
+  }
+
+  @Test
+  public void getTypeClass_CommaSeparatorPlainIntegerStillNumeric() {
+    // An integer without any separator is still a valid number regardless of the configured separator.
+    var result = DatatypeUtils.getTypeClass("42", false, ',');
+    assertEquals(Integer.class, result);
   }
 
   @Test
@@ -315,6 +329,14 @@ public class DatatypeUtilsTest {
   public void convertValue_DefaultSeparatorDotStillWorks() {
     var actualValue = DatatypeUtils.convertValue(TEST_ADAPTER_NAME, "123.45", XSD.FLOAT.toString());
     assertEquals(123.45f, actualValue);
+  }
+
+  @Test
+  public void convertValue_CommaSeparatorKeepsDotValueAsString() {
+    // With ',' selected, "100.000" is not numeric and the raw value is returned unchanged.
+    var actualValue = DatatypeUtils.convertValue(
+        TEST_ADAPTER_NAME, "100.000", XSD.STRING.toString(), ',', new java.util.concurrent.atomic.AtomicBoolean(false));
+    assertEquals("100.000", actualValue);
   }
 
 }

--- a/streampipes-extensions-management/src/main/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParser.java
+++ b/streampipes-extensions-management/src/main/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParser.java
@@ -62,12 +62,16 @@ public class CsvParser implements IParser {
 
   public static final String DELIMITER = "delimiter";
   public static final String HEADER = "header";
+  public static final String DECIMAL_SEPARATOR = "decimalSeparator";
 
   public static final String DESCRIPTION = "Can be used to read CSV";
+
+  private static final char DEFAULT_DECIMAL_SEPARATOR = '.';
 
 
   private boolean header;
   private char delimiter;
+  private char decimalSeparator = DEFAULT_DECIMAL_SEPARATOR;
   private final AtomicBoolean loggedConversionError = new AtomicBoolean(false);
 
   public CsvParser() {
@@ -75,9 +79,14 @@ public class CsvParser implements IParser {
   }
 
   public CsvParser(boolean header, char delimiter) {
+    this(header, delimiter, DEFAULT_DECIMAL_SEPARATOR);
+  }
+
+  public CsvParser(boolean header, char delimiter, char decimalSeparator) {
     this();
     this.header = header;
     this.delimiter = delimiter;
+    this.decimalSeparator = decimalSeparator;
   }
 
   @Override
@@ -91,7 +100,18 @@ public class CsvParser implements IParser {
                               .stream()
                               .anyMatch("Header"::equals);
 
-    return new CsvParser(header, delimiter);
+    char decimalSeparator = DEFAULT_DECIMAL_SEPARATOR;
+    try {
+      var separatorValue = extractor.singleValueParameter(DECIMAL_SEPARATOR, String.class);
+      if (separatorValue != null && !separatorValue.isEmpty()) {
+        decimalSeparator = separatorValue.charAt(0);
+      }
+    } catch (RuntimeException e) {
+      // Keep backwards compatibility with adapter descriptions persisted before this option existed.
+      LOG.debug("No decimal separator configured, falling back to default '{}'", DEFAULT_DECIMAL_SEPARATOR);
+    }
+
+    return new CsvParser(header, delimiter, decimalSeparator);
   }
 
 
@@ -109,6 +129,10 @@ public class CsvParser implements IParser {
                                        ),
                                        List.of(new Option("Header", "Header"))
                                    )
+                                   .requiredTextParameter(Labels.from(
+                                       DECIMAL_SEPARATOR, "Decimal separator",
+                                       "The decimal separator used for numeric values, e.g. . or ,"
+                                   ))
                                    .build();
   }
 
@@ -164,8 +188,9 @@ public class CsvParser implements IParser {
 
     var event = new HashMap<String, Object>();
     for (int i = 0; i < header.length; i++) {
-      var runtimeType = DatatypeUtils.getXsdDatatype(values[i], preferFloat);
-      var convertedValue = DatatypeUtils.convertValue(ID, values[i], runtimeType, loggedConversionError);
+      var runtimeType = DatatypeUtils.getXsdDatatype(values[i], preferFloat, decimalSeparator);
+      var convertedValue =
+          DatatypeUtils.convertValue(ID, values[i], runtimeType, decimalSeparator, loggedConversionError);
       event.put(header[i], convertedValue);
     }
 

--- a/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParserTest.java
+++ b/streampipes-extensions-management/src/test/java/org/apache/streampipes/extensions/management/connect/adapter/parser/CsvParserTest.java
@@ -106,4 +106,19 @@ public class CsvParserTest extends ParserTest {
     verify(mockEventHandler).handle(expectedEvent);
   }
 
+  @Test
+  public void parseCommaDecimalSeparatorWithSemicolonDelimiter() {
+    // Column delimiter ';' frees ',' to act as the decimal separator (issue #530).
+    var event = toStream("k1;k2\nv1;2,5");
+    var mockEventHandler = mock(IParserEventHandler.class);
+
+    var parser = new CsvParser(true, ';', ',');
+    parser.parse(event, mockEventHandler);
+
+    Map<String, Object> expectedEvent = new HashMap<>();
+    expectedEvent.put(K1, "v1");
+    expectedEvent.put(K2, 2.5f);
+    verify(mockEventHandler).handle(expectedEvent);
+  }
+
 }

--- a/ui/cypress/support/utils/ProcessingElementTestUtils.ts
+++ b/ui/cypress/support/utils/ProcessingElementTestUtils.ts
@@ -63,7 +63,11 @@ export class ProcessingElementTestUtils {
             adapterInputBuilder
                 .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
                 .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
-                .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
+                .addFormatInput(
+                    'input',
+                    ConnectBtns.csvDecimalSeparator(),
+                    '.',
+                );
         } else if (formatType === 'json') {
             adapterInputBuilder.addFormatInput(
                 'radio',

--- a/ui/cypress/support/utils/ProcessingElementTestUtils.ts
+++ b/ui/cypress/support/utils/ProcessingElementTestUtils.ts
@@ -62,7 +62,8 @@ export class ProcessingElementTestUtils {
         if (formatType === 'csv') {
             adapterInputBuilder
                 .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
-                .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check');
+                .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+                .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
         } else if (formatType === 'json') {
             adapterInputBuilder.addFormatInput(
                 'radio',

--- a/ui/cypress/support/utils/connect/ConnectBtns.ts
+++ b/ui/cypress/support/utils/connect/ConnectBtns.ts
@@ -433,6 +433,10 @@ export class ConnectBtns {
         return 'format-org.apache.streampipes.extensions.management.connect.adapter.parser.csv-1-header-1';
     }
 
+    public static csvDecimalSeparator() {
+        return 'format-org.apache.streampipes.extensions.management.connect.adapter.parser.csv-1-decimalSeparator-2';
+    }
+
     public static jsonArrayFieldKey() {
         return 'format-org.apache.streampipes.extensions.management.connect.adapter.parser.json-0-json_options-0-arrayFieldConfig-2-key-0';
     }

--- a/ui/cypress/support/utils/connect/ConnectUtils.ts
+++ b/ui/cypress/support/utils/connect/ConnectUtils.ts
@@ -433,7 +433,11 @@ export class ConnectUtils {
                 .setFormat('csv')
                 .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
                 .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
-                .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
+                .addFormatInput(
+                    'input',
+                    ConnectBtns.csvDecimalSeparator(),
+                    '.',
+                );
         }
 
         if (overwriteTimestamp) {

--- a/ui/cypress/support/utils/connect/ConnectUtils.ts
+++ b/ui/cypress/support/utils/connect/ConnectUtils.ts
@@ -432,7 +432,8 @@ export class ConnectUtils {
                 .setName('Adapter to test rules')
                 .setFormat('csv')
                 .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
-                .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check');
+                .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+                .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
         }
 
         if (overwriteTimestamp) {

--- a/ui/cypress/support/utils/connect/ConnectUtils.ts
+++ b/ui/cypress/support/utils/connect/ConnectUtils.ts
@@ -213,8 +213,12 @@ export class ConnectUtils {
         }
 
         // For file adapters, wait until the file selection state is rendered to reduce test flakiness.
+        // Scroll it into view first, since additional format options (e.g. the decimal separator)
+        // can push this element into a scrollable area.
         if (adapterInput?.adapterType === 'File_Stream') {
-            ConnectBtns.fileInputSelected().should('be.visible');
+            ConnectBtns.fileInputSelected()
+                .scrollIntoView()
+                .should('be.visible');
         }
     }
 

--- a/ui/cypress/support/utils/userInput/StaticPropertyUtils.ts
+++ b/ui/cypress/support/utils/userInput/StaticPropertyUtils.ts
@@ -69,6 +69,7 @@ export class StaticPropertyUtils {
                     });
             } else if (config.type === 'input') {
                 cy.dataCy(config.selector, { timeout: 2000 })
+                    .scrollIntoView()
                     .clear()
                     .type(config.value)
                     .blur();
@@ -104,9 +105,11 @@ export class StaticPropertyUtils {
     }
 
     private static clickSelectionInput(selector: string, cssClassName: string) {
-        cy.dataCy(selector, { timeout: 2000 }).within(() => {
-            cy.get(cssClassName).click();
-        });
+        cy.dataCy(selector, { timeout: 2000 })
+            .scrollIntoView()
+            .within(() => {
+                cy.get(cssClassName).click();
+            });
     }
 
     private static preserveClosingTemplateSuffix(

--- a/ui/cypress/tests/connect/fileStream.spec.ts
+++ b/ui/cypress/tests/connect/fileStream.spec.ts
@@ -37,6 +37,7 @@ describe('Test File Replay Adapter', () => {
             .setFormat('csv')
             .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
             .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.')
             .build();
 
         ConnectUtils.testAdapter(adapterInput);
@@ -101,6 +102,7 @@ describe('Test File Replay Adapter', () => {
             .setFormat('csv')
             .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
             .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.')
             .setStartAdapter(false)
             .build();
 

--- a/ui/cypress/tests/connect/formats/format.spec.ts
+++ b/ui/cypress/tests/connect/formats/format.spec.ts
@@ -104,7 +104,8 @@ describe('Test adapter formats', () => {
         template
             .setFormat('csv')
             .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
-            .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check');
+            .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
 
         createAdapterUntilEventSchemaConfiguration(template.build());
 
@@ -118,7 +119,8 @@ describe('Test adapter formats', () => {
         const template = makeAdapterInputTemplate();
         template
             .setFormat('csv')
-            .addFormatInput('input', ConnectBtns.csvDelimiter(), ';');
+            .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
 
         createAdapterUntilEventSchemaConfiguration(template.build());
 
@@ -141,7 +143,8 @@ describe('Test adapter formats', () => {
         template
             .setFormat('csv')
             .addFormatInput('input', ConnectBtns.csvDelimiter(), ',')
-            .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check');
+            .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.');
 
         createAdapterUntilEventSchemaConfiguration(template.build());
 

--- a/ui/cypress/tests/connect/persistInDataLake.smoke.spec.ts
+++ b/ui/cypress/tests/connect/persistInDataLake.smoke.spec.ts
@@ -37,6 +37,7 @@ describe('Test File Stream Adapter', () => {
             .setFormat('csv')
             .addFormatInput('input', ConnectBtns.csvDelimiter(), ';')
             .addFormatInput('checkbox', ConnectBtns.csvHeader(), 'check')
+            .addFormatInput('input', ConnectBtns.csvDecimalSeparator(), '.')
             .build();
 
         ConnectUtils.testAdapter(adapterInput);


### PR DESCRIPTION
Closes #530

CSV values using `,` as the decimal separator were detected as strings instead of numbers. This adds a "Decimal separator" option to the CSV parser and makes `DatatypeUtils` normalize the configured separator before numeric detection.

Behavior is additive and backward-compatible: existing `DatatypeUtils` overloads default to `.`, and normalization is skipped for ambiguous values (e.g. `1,000,000`) to avoid corrupting grouped numbers.

**Tested:** new unit tests in `DatatypeUtilsTest` (comma decimals + guard cases) and `CsvParserTest` (`;` delimiter with `,` decimals). `mvn test` green for both affected modules with 0 checkstyle violations.

**Open question for maintainers:** I implemented lenient behavior (configuring `,` still also accepts `.`-values). Happy to switch to strict locale honoring if preferred.
