### PR TITLE
fix(#4891): restore icon spacing in Material buttons

### DIFF
--- a/ui/projects/streampipes/shared-ui/src/lib/components/alert-banner/alert-banner.component.html
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/alert-banner/alert-banner.component.html
@@ -42,9 +42,7 @@
                     [class.mat-basic]="type !== 'error'"
                     (click)="detailsButtonClicked.emit()"
                 >
-                    <i class="material-icons">visibility</i>&nbsp;{{
-                        'Details' | translate
-                    }}
+                    <mat-icon>visibility</mat-icon>{{ 'Details' | translate }}
                 </button>
             </div>
         }

--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-filter/asset-browser-filter.component.html
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-filter/asset-browser-filter.component.html
@@ -46,7 +46,7 @@
                     color="accent"
                     (click)="refreshAssets()"
                 >
-                    <i class="material-icons"> refresh </i>
+                    <mat-icon> refresh </mat-icon>
                 </button>
                 <div fxLayout="row" fxLayoutGap="10px">
                     <button

--- a/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-filter/asset-browser-filter.component.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/components/asset-browser/asset-browser-toolbar/asset-browser-filter/asset-browser-filter.component.ts
@@ -41,6 +41,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-asset-browser-filter',
@@ -59,6 +60,7 @@ import { MatTooltip } from '@angular/material/tooltip';
         TranslatePipe,
         MatIconButton,
         MatTooltip,
+        MatIcon,
     ],
 })
 export class AssetBrowserFilterComponent implements OnInit, OnDestroy {

--- a/ui/projects/streampipes/shared-ui/src/lib/dialog/object-manage-dialog/object-manage-dialog.component.html
+++ b/ui/projects/streampipes/shared-ui/src/lib/dialog/object-manage-dialog/object-manage-dialog.component.html
@@ -285,8 +285,8 @@
                     "
                     data-cy="sp-manage-save"
                 >
-                    <i class="material-icons">save</i>
-                    <span>&nbsp;{{ saveButtonLabel | translate }}</span>
+                    <mat-icon>save</mat-icon>
+                    <span>{{ saveButtonLabel | translate }}</span>
                 </button>
             }
             <button

--- a/ui/projects/streampipes/shared-ui/src/lib/dialog/panel-dialog/panel-dialog.component.html
+++ b/ui/projects/streampipes/shared-ui/src/lib/dialog/panel-dialog/panel-dialog.component.html
@@ -20,9 +20,7 @@
     <div class="dialog-panel-header">
         <span class="dialog-title">{{ dialogTitle }}</span>
         <button mat-icon-button (click)="close()" class="mr-10">
-            <i class="material-icons" style="font-size: 25px; color: white"
-                >clear</i
-            >
+            <mat-icon>clear</mat-icon>
         </button>
     </div>
     <div class="dialog-panel-content">

--- a/ui/projects/streampipes/shared-ui/src/lib/dialog/panel-dialog/panel-dialog.component.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/dialog/panel-dialog/panel-dialog.component.ts
@@ -34,6 +34,7 @@ import {
 import { BaseDialogComponent } from '../base-dialog/base-dialog.component';
 import { MatIconButton } from '@angular/material/button';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-panel-dialog-container',
@@ -63,7 +64,7 @@ import { CdkPortalOutlet } from '@angular/cdk/portal';
             transition('* => *', animate(300)),
         ]),
     ],
-    imports: [MatIconButton, CdkPortalOutlet],
+    imports: [MatIconButton, CdkPortalOutlet, MatIcon],
 })
 export class PanelDialogComponent<T> extends BaseDialogComponent<T> {
     constructor() {

--- a/ui/projects/streampipes/shared-ui/src/lib/dialog/standard-dialog/standard-dialog.component.html
+++ b/ui/projects/streampipes/shared-ui/src/lib/dialog/standard-dialog/standard-dialog.component.html
@@ -20,9 +20,7 @@
     <div class="standard-dialog-panel-header">
         <span class="dialog-title">{{ dialogTitle }}</span>
         <button mat-icon-button (click)="close()" class="mr-5">
-            <i class="material-icons" style="font-size: 25px; color: white"
-                >clear</i
-            >
+            <mat-icon>clear</mat-icon>
         </button>
     </div>
     <div class="dialog-panel-content">

--- a/ui/projects/streampipes/shared-ui/src/lib/dialog/standard-dialog/standard-dialog.component.ts
+++ b/ui/projects/streampipes/shared-ui/src/lib/dialog/standard-dialog/standard-dialog.component.ts
@@ -20,13 +20,14 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { BaseDialogComponent } from '../base-dialog/base-dialog.component';
 import { MatIconButton } from '@angular/material/button';
 import { CdkPortalOutlet } from '@angular/cdk/portal';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-standard-dialog-container',
     templateUrl: './standard-dialog.component.html',
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['./standard-dialog.component.scss'],
-    imports: [MatIconButton, CdkPortalOutlet],
+    imports: [MatIconButton, CdkPortalOutlet, MatIcon],
 })
 export class StandardDialogComponent<T> extends BaseDialogComponent<T> {
     constructor() {

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.html
@@ -26,8 +26,8 @@
                 (click)="openManageAssetLinksDialog()"
                 data-cy="assets-manage-links-button"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'Manage links' | translate }}</span>
+                <mat-icon>add</mat-icon
+                ><span>{{ 'Manage links' | translate }}</span>
             </button>
         }
         @if (editMode) {
@@ -37,8 +37,8 @@
                 class="mat-basic"
                 (click)="openCreateAssetLinkDialog()"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'Add link' | translate }}</span>
+                <mat-icon>add</mat-icon
+                ><span>{{ 'Add link' | translate }}</span>
             </button>
         }
     </div>

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details-panel/asset-details-links/asset-details-links.component.ts
@@ -49,6 +49,7 @@ import {
     LayoutGapDirective,
 } from '@ngbracket/ngx-layout/flex';
 import { MatButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-asset-details-links',
@@ -61,6 +62,7 @@ import { MatButton } from '@angular/material/button';
         FlexDirective,
         AssetLinkTableComponent,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class AssetDetailsLinksComponent implements OnInit {

--- a/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
+++ b/ui/src/app/assets/components/asset-details/edit-asset/asset-details.component.html
@@ -56,7 +56,7 @@
                     color="accent"
                     (click)="saveAsset()"
                 >
-                    <i class="material-icons" aria-hidden="true">save</i>
+                    <mat-icon aria-hidden="true">save</mat-icon>
                     <span>{{ 'Save' | translate }}</span>
                 </button>
                 @if (!isNewAsset) {

--- a/ui/src/app/assets/components/asset-overview/asset-overview.component.html
+++ b/ui/src/app/assets/components/asset-overview/asset-overview.component.html
@@ -31,7 +31,7 @@
                 data-cy="create-new-asset-button"
                 (click)="createNewAsset()"
             >
-                <i class="material-icons" aria-hidden="true">add</i>&nbsp;
+                <mat-icon aria-hidden="true">add</mat-icon>
                 {{ 'New asset' | translate }}
             </button>
         }
@@ -45,7 +45,7 @@
             color="accent"
             (click)="loadAssets()"
         >
-            <i class="material-icons" aria-hidden="true">refresh</i>
+            <mat-icon aria-hidden="true">refresh</mat-icon>
         </button>
     </sp-page-header>
     <div fxFlex="100" fxLayout="column">

--- a/ui/src/app/chart-shared/components/chart-config/color-mapping-options-config/color-mapping-options-config.component.html
+++ b/ui/src/app/chart-shared/components/chart-config/color-mapping-options-config/color-mapping-options-config.component.html
@@ -43,7 +43,7 @@
                     (click)="addMapping()"
                 >
                     <mat-icon>add</mat-icon>
-                    <span>&nbsp;{{ 'Add Mapping' | translate }}</span>
+                    <span>{{ 'Add Mapping' | translate }}</span>
                 </button>
             </div>
             <div fxLayout="column" fxLayoutGap="10px">
@@ -109,7 +109,7 @@
                                 color="accent"
                                 (click)="removeMapping(i)"
                             >
-                                <i class="material-icons">delete</i>
+                                <mat-icon>delete</mat-icon>
                             </button>
                         </div>
                     </div>

--- a/ui/src/app/chart-shared/components/chart-config/select-color-properties-config/time-series-item-config/time-series-item-config.component.html
+++ b/ui/src/app/chart-shared/components/chart-config/select-color-properties-config/time-series-item-config/time-series-item-config.component.html
@@ -50,9 +50,7 @@
             (click)="toggleExpand()"
             [disabled]="!isSelected(field)"
         >
-            <i class="material-icons">{{
-                expanded ? 'expand_less' : 'expand_more'
-            }}</i>
+            <mat-icon>{{ expanded ? 'expand_less' : 'expand_more' }}</mat-icon>
         </button>
     </div>
     @if (isSelected(field) && expanded) {

--- a/ui/src/app/chart-shared/components/chart-config/select-color-properties-config/time-series-item-config/time-series-item-config.component.ts
+++ b/ui/src/app/chart-shared/components/chart-config/select-color-properties-config/time-series-item-config/time-series-item-config.component.ts
@@ -42,6 +42,7 @@ import { TranslatePipe } from '@ngx-translate/core';
 import { ColorMappingOptionsConfigComponent } from '../../color-mapping-options-config/color-mapping-options-config.component';
 import { LayoutDirective } from '@ngbracket/ngx-layout';
 import { ResultLabelService } from '../../../../services/result-label.service';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-time-series-item-config',
@@ -66,6 +67,7 @@ import { ResultLabelService } from '../../../../services/result-label.service';
         TranslatePipe,
         ColorMappingOptionsConfigComponent,
         LayoutDirective,
+        MatIcon,
     ],
 })
 export class SpTimeseriesItemConfigComponent {

--- a/ui/src/app/chart/components/chart-overview/chart-overview.component.html
+++ b/ui/src/app/chart/components/chart-overview/chart-overview.component.html
@@ -34,7 +34,7 @@
                 data-cy="open-new-chart"
                 (click)="createNewChart()"
             >
-                <i class="material-icons" aria-hidden="true">add</i>
+                <mat-icon aria-hidden="true">add</mat-icon>
                 <span>{{ 'New chart' | translate }}</span>
             </button>
         }

--- a/ui/src/app/chart/components/chart-overview/chart-overview.component.ts
+++ b/ui/src/app/chart/components/chart-overview/chart-overview.component.ts
@@ -33,6 +33,7 @@ import { Subscription } from 'rxjs';
 import { MatButton } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { AsyncPipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-chart-overview',
@@ -45,6 +46,7 @@ import { AsyncPipe } from '@angular/common';
         ChartOverviewTableComponent,
         TranslatePipe,
         AsyncPipe,
+        MatIcon,
     ],
 })
 export class ChartOverviewComponent implements OnInit, OnDestroy {

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-condition-row/advanced-filter-condition-row.component.html
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-condition-row/advanced-filter-condition-row.component.html
@@ -47,6 +47,6 @@
     }
 
     <button mat-icon-button color="accent" (click)="onRemove()">
-        <i class="material-icons">remove</i>
+        <mat-icon>remove</mat-icon>
     </button>
 </div>

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-condition-row/advanced-filter-condition-row.component.ts
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-condition-row/advanced-filter-condition-row.component.ts
@@ -34,6 +34,7 @@ import { FilterSelectionPanelRowOperationSelectionComponent } from '../../filter
 import { FilterSelectionPanelRowValueInputComponent } from '../../filter-selection-panel-row/panel-row-value-input/filter-selection-panel-row-value-input.component';
 import { FilterSelectionPanelRowValueAutocompleteComponent } from '../../filter-selection-panel-row/panel-row-value-input-autocomplete/filter-selection-panel-row-value-autocomplete.component';
 import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-advanced-filter-condition-row',
@@ -44,6 +45,7 @@ import { MatIconButton } from '@angular/material/button';
         FilterSelectionPanelRowValueInputComponent,
         FilterSelectionPanelRowValueAutocompleteComponent,
         MatIconButton,
+        MatIcon,
     ],
 })
 export class AdvancedFilterConditionRowComponent implements OnChanges {

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-dialog.component.html
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-dialog.component.html
@@ -136,7 +136,7 @@
                             (click)="removeChild(group, i)"
                             class="advanced-filter-remove-group"
                         >
-                            <i class="material-icons">remove</i>
+                            <mat-icon>remove</mat-icon>
                         </button>
 
                         <ng-container

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-dialog.component.ts
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/advanced-filter-dialog/advanced-filter-dialog.component.ts
@@ -42,6 +42,7 @@ import {
 } from '@ngbracket/ngx-layout';
 import { MatDivider } from '@angular/material/list';
 import { FilterExpressionPreviewService } from '../filter-expression-preview.service';
+import { MatIcon } from '@angular/material/icon';
 
 export interface AdvancedFilterDialogResult {
     action: 'save' | 'clear';
@@ -68,6 +69,7 @@ export interface AdvancedFilterDialogResult {
         FlexDirective,
         LayoutDirective,
         LayoutAlignDirective,
+        MatIcon,
     ],
 })
 export class AdvancedFilterDialogComponent implements OnInit {

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/filter-selection-panel-row/filter-selection-panel-row.component.html
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/filter-selection-panel-row/filter-selection-panel-row.component.html
@@ -74,7 +74,7 @@
             (click)="remove()"
             data-cy="design-panel-data-settings-remove-filter"
         >
-            <i class="material-icons">remove</i>
+            <mat-icon>remove</mat-icon>
         </button>
     </div>
 </div>

--- a/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/filter-selection-panel-row/filter-selection-panel-row.component.ts
+++ b/ui/src/app/chart/components/chart-view/designer-panel/data-settings/filter-selection-panel/filter-selection-panel-row/filter-selection-panel-row.component.ts
@@ -30,6 +30,7 @@ import { FilterSelectionPanelRowValueAutocompleteComponent } from './panel-row-v
 import { MatIconButton } from '@angular/material/button';
 import { MatFormField } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-filter-selection-panel-row',
@@ -46,6 +47,7 @@ import { MatOption, MatSelect } from '@angular/material/select';
         MatFormField,
         MatSelect,
         MatOption,
+        MatIcon,
     ],
 })
 export class FilterSelectionPanelRowComponent {

--- a/ui/src/app/configuration/email-configuration/email-configuration.component.html
+++ b/ui/src/app/configuration/email-configuration/email-configuration.component.html
@@ -233,8 +233,8 @@
                             [disabled]="!parentForm.valid"
                             data-cy="sp-element-email-config-save"
                         >
-                            <i class="material-icons">save</i
-                            ><span>&nbsp;{{ 'Save' | translate }}</span>
+                            <mat-icon>save</mat-icon
+                            ><span>{{ 'Save' | translate }}</span>
                         </button>
                         <button
                             mat-button

--- a/ui/src/app/configuration/email-configuration/email-configuration.component.ts
+++ b/ui/src/app/configuration/email-configuration/email-configuration.component.ts
@@ -49,6 +49,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatButton } from '@angular/material/button';
 import { SpEmailTemplateConfigurationComponent } from './email-template-configuration/email-template-configuration.component';
 import { MatDivider } from '@angular/material/divider';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-email-configuration',
@@ -73,6 +74,7 @@ import { MatDivider } from '@angular/material/divider';
         SpEmailTemplateConfigurationComponent,
         MatDivider,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class EmailConfigurationComponent implements OnInit {

--- a/ui/src/app/configuration/email-configuration/email-template-configuration/email-template-configuration.component.html
+++ b/ui/src/app/configuration/email-configuration/email-template-configuration/email-template-configuration.component.html
@@ -78,8 +78,8 @@
                     (click)="saveTemplate()"
                     [disabled]="template.template === ''"
                 >
-                    <i class="material-icons">save</i
-                    ><span>&nbsp;{{ 'Save' | translate }}</span>
+                    <mat-icon>save</mat-icon
+                    ><span>{{ 'Save' | translate }}</span>
                 </button>
             </div>
         </div>

--- a/ui/src/app/configuration/email-configuration/email-template-configuration/email-template-configuration.component.ts
+++ b/ui/src/app/configuration/email-configuration/email-template-configuration/email-template-configuration.component.ts
@@ -37,6 +37,7 @@ import {
 import { MatButton } from '@angular/material/button';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import type { editor as MonacoEditor } from 'monaco-editor';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-email-template-configuration',
@@ -53,6 +54,7 @@ import type { editor as MonacoEditor } from 'monaco-editor';
         MonacoEditorModule,
         FormsModule,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SpEmailTemplateConfigurationComponent implements OnInit {

--- a/ui/src/app/configuration/export/data-export-import.component.html
+++ b/ui/src/app/configuration/export/data-export-import.component.html
@@ -61,8 +61,8 @@
                     (click)="openExportDialog()"
                     data-cy="export-asset-button"
                 >
-                    <i class="material-icons">cloud_download</i
-                    ><span>&nbsp;{{ 'Start export process' | translate }}</span>
+                    <mat-icon>cloud_download</mat-icon
+                    ><span>{{ 'Start export process' | translate }}</span>
                 </button>
             </div>
         </sp-split-section>
@@ -80,8 +80,8 @@
                     (click)="openImportDialog()"
                     data-cy="import-application-data-button"
                 >
-                    <i class="material-icons">cloud_upload</i
-                    ><span>&nbsp;{{ 'Start import process' | translate }}</span>
+                    <mat-icon>cloud_upload</mat-icon
+                    ><span>{{ 'Start import process' | translate }}</span>
                 </button>
             </div>
         </sp-split-section>

--- a/ui/src/app/configuration/export/data-export-import.component.ts
+++ b/ui/src/app/configuration/export/data-export-import.component.ts
@@ -49,6 +49,7 @@ import {
 import { MatButton } from '@angular/material/button';
 import { forkJoin, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { MatIcon } from '@angular/material/icon';
 
 interface AssetReferenceExportItems {
     referencedLabels: Record<string, ExportItem[]>;
@@ -68,6 +69,7 @@ interface AssetReferenceExportItems {
         MatCheckbox,
         MatButton,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SpDataExportImportComponent implements OnInit {

--- a/ui/src/app/configuration/export/export-dialog/data-export-dialog.component.html
+++ b/ui/src/app/configuration/export/export-dialog/data-export-dialog.component.html
@@ -234,8 +234,8 @@
                     (click)="generateDownloadPackage()"
                     data-cy="download-export-button"
                 >
-                    <i class="material-icons">file_download</i
-                    ><span>&nbsp;{{ 'Download export' | translate }}</span>
+                    <mat-icon>file_download</mat-icon
+                    ><span>{{ 'Download export' | translate }}</span>
                 </button>
                 <button
                     mat-button

--- a/ui/src/app/configuration/export/export-dialog/data-export-dialog.component.ts
+++ b/ui/src/app/configuration/export/export-dialog/data-export-dialog.component.ts
@@ -46,6 +46,7 @@ import { FormsModule } from '@angular/forms';
 import { MatFormField } from '@angular/material/form-field';
 import { MatOption, MatSelect } from '@angular/material/select';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 interface SectionAssetConfiguration {
     assetId: string;
@@ -84,6 +85,7 @@ type ExportSectionKey =
         SplitSectionComponent,
         TranslatePipe,
         SpAlertBannerComponent,
+        MatIcon,
     ],
 })
 export class SpDataExportDialogComponent implements OnInit {

--- a/ui/src/app/configuration/export/export-dialog/generic-storage-items/generic-storage-item/generic-storage-item.component.html
+++ b/ui/src/app/configuration/export/export-dialog/generic-storage-items/generic-storage-item/generic-storage-item.component.html
@@ -25,7 +25,7 @@
                 color="accent"
                 (click)="removeItem.emit(exportItem.resourceId)"
             >
-                <i class="material-icons">remove</i>
+                <mat-icon>remove</mat-icon>
             </button>
         </div>
     } @else {

--- a/ui/src/app/configuration/export/export-dialog/generic-storage-items/generic-storage-item/generic-storage-item.component.ts
+++ b/ui/src/app/configuration/export/export-dialog/generic-storage-items/generic-storage-item/generic-storage-item.component.ts
@@ -25,6 +25,7 @@ import {
 } from '@ngbracket/ngx-layout/flex';
 import { MatIconButton } from '@angular/material/button';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-generic-storage-item',
@@ -35,6 +36,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
         FlexDirective,
         MatIconButton,
         MatCheckbox,
+        MatIcon,
     ],
 })
 export class GenericStorageItemComponent {

--- a/ui/src/app/configuration/export/import-dialog/data-import-dialog.component.html
+++ b/ui/src/app/configuration/export/import-dialog/data-import-dialog.component.html
@@ -225,7 +225,7 @@
                         [disabled]="!hasInput"
                         data-cy="next-import-button"
                     >
-                        <span>&nbsp;{{ 'Next' | translate }}</span>
+                        <span>{{ 'Next' | translate }}</span>
                     </button>
                 }
                 @if (currentImportStep === 1) {
@@ -237,8 +237,8 @@
                         (click)="performImport()"
                         data-cy="import-button"
                     >
-                        <i class="material-icons">file_download</i
-                        ><span>&nbsp;{{ 'Import data' | translate }}</span>
+                        <mat-icon>file_download</mat-icon
+                        ><span>{{ 'Import data' | translate }}</span>
                     </button>
                 }
                 @if (currentImportStep > 0) {

--- a/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-configuration.component.html
+++ b/ui/src/app/configuration/extensions-service-management/certificate-configuration/certificate-configuration.component.html
@@ -100,8 +100,8 @@
                         "
                         (click)="openDetailsDialog(certificate)"
                     >
-                        <i class="material-icons">search</i>
-                        <span>&nbsp;{{ 'Details' | translate }}</span>
+                        <mat-icon>search</mat-icon>
+                        <span>{{ 'Details' | translate }}</span>
                     </button>
                     <button
                         mat-flat-button
@@ -112,16 +112,14 @@
                         "
                         data-cy="trust-certificate-button"
                     >
-                        <i class="material-icons">{{
+                        <mat-icon>{{
                             certificate.state === 'TRUSTED' ? 'cancel' : 'check'
-                        }}</i>
-                        <span
-                            >&nbsp;{{
-                                certificate.state === 'TRUSTED'
-                                    ? ('Reject' | translate)
-                                    : ('Trust' | translate)
-                            }}</span
-                        >
+                        }}</mat-icon>
+                        <span>{{
+                            certificate.state === 'TRUSTED'
+                                ? ('Reject' | translate)
+                                : ('Trust' | translate)
+                        }}</span>
                     </button>
                     <button
                         mat-flat-button
@@ -133,8 +131,8 @@
                         "
                         (click)="onDelete(certificate)"
                     >
-                        <i class="material-icons">delete</i>
-                        <span>&nbsp;{{ 'Delete' | translate }}</span>
+                        <mat-icon>delete</mat-icon>
+                        <span>{{ 'Delete' | translate }}</span>
                     </button>
                 </div>
             </td>

--- a/ui/src/app/configuration/files/file-overview/file-overview.component.html
+++ b/ui/src/app/configuration/files/file-overview/file-overview.component.html
@@ -55,7 +55,7 @@
                     (click)="downloadFile(fileMetadata)"
                     data-cy="download"
                 >
-                    <i class="material-icons">download</i>
+                    <mat-icon>download</mat-icon>
                 </button>
                 <button
                     color="accent"
@@ -65,7 +65,7 @@
                     (click)="deleteFile(fileMetadata)"
                     data-cy="delete"
                 >
-                    <i class="material-icons">delete</i>
+                    <mat-icon>delete</mat-icon>
                 </button>
             </div>
         </td>

--- a/ui/src/app/configuration/files/file-overview/file-overview.component.ts
+++ b/ui/src/app/configuration/files/file-overview/file-overview.component.ts
@@ -42,6 +42,7 @@ import {
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { DatePipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-file-overview',
@@ -62,6 +63,7 @@ import { DatePipe } from '@angular/common';
         MatTooltip,
         DatePipe,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class FileOverviewComponent implements OnInit {

--- a/ui/src/app/configuration/files/files.component.html
+++ b/ui/src/app/configuration/files/files.component.html
@@ -37,8 +37,8 @@
                 data-cy="sp-open-file-upload-dialog"
                 class="mr-10"
             >
-                <i class="material-icons">cloud_upload</i>
-                &nbsp;{{ 'Upload new file' | translate }}
+                <mat-icon>cloud_upload</mat-icon>
+                {{ 'Upload new file' | translate }}
             </button>
         </div>
 

--- a/ui/src/app/configuration/files/files.component.ts
+++ b/ui/src/app/configuration/files/files.component.ts
@@ -35,6 +35,7 @@ import {
 } from '@ngbracket/ngx-layout/flex';
 import { MatButton } from '@angular/material/button';
 import { FileOverviewComponent } from './file-overview/file-overview.component';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     templateUrl: './files.component.html',
@@ -48,6 +49,7 @@ import { FileOverviewComponent } from './file-overview/file-overview.component';
         FlexDirective,
         FileOverviewComponent,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class FilesComponent implements OnInit {

--- a/ui/src/app/configuration/label-configuration/label-configuration.component.html
+++ b/ui/src/app/configuration/label-configuration/label-configuration.component.html
@@ -37,8 +37,7 @@
                 data-cy="new-label-button"
                 (click)="createLabelMode.set(true)"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'New' | translate }}</span>
+                <mat-icon>add</mat-icon><span>{{ 'New' | translate }}</span>
             </button>
         </div>
         @if (createLabelMode()) {

--- a/ui/src/app/configuration/security-configuration/edit-group-dialog/edit-group-dialog.component.html
+++ b/ui/src/app/configuration/security-configuration/edit-group-dialog/edit-group-dialog.component.html
@@ -73,8 +73,7 @@
                 [disabled]="!parentForm.valid || clonedGroup.roles.length === 0"
                 data-cy="sp-element-edit-user-save"
             >
-                <i class="material-icons">save</i
-                ><span>&nbsp;{{ 'Save' | translate }}</span>
+                <mat-icon>save</mat-icon><span>{{ 'Save' | translate }}</span>
             </button>
             <button
                 mat-button

--- a/ui/src/app/configuration/security-configuration/edit-group-dialog/edit-group-dialog.component.ts
+++ b/ui/src/app/configuration/security-configuration/edit-group-dialog/edit-group-dialog.component.ts
@@ -49,6 +49,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatButton } from '@angular/material/button';
 import { AsyncPipe } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-edit-group-dialog',
@@ -70,6 +71,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         MatButton,
         AsyncPipe,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class EditGroupDialogComponent implements OnInit {

--- a/ui/src/app/configuration/security-configuration/edit-role-dialog/edit-role-dialog.component.html
+++ b/ui/src/app/configuration/security-configuration/edit-role-dialog/edit-role-dialog.component.html
@@ -137,8 +137,7 @@
                 "
                 data-cy="sp-edit-role-save"
             >
-                <i class="material-icons">save</i
-                ><span>&nbsp;{{ 'Save' | translate }}</span>
+                <mat-icon>save</mat-icon><span>{{ 'Save' | translate }}</span>
             </button>
             <button
                 mat-button

--- a/ui/src/app/configuration/security-configuration/edit-user-dialog/edit-user-dialog.component.html
+++ b/ui/src/app/configuration/security-configuration/edit-user-dialog/edit-user-dialog.component.html
@@ -261,8 +261,8 @@
                         "
                         data-cy="sp-element-edit-user-save"
                     >
-                        <i class="material-icons">save</i
-                        ><span>&nbsp;{{ 'Save' | translate }}</span>
+                        <mat-icon>save</mat-icon
+                        ><span>{{ 'Save' | translate }}</span>
                     </button>
                     <button
                         mat-flat-button

--- a/ui/src/app/configuration/security-configuration/edit-user-dialog/edit-user-dialog.component.ts
+++ b/ui/src/app/configuration/security-configuration/edit-user-dialog/edit-user-dialog.component.ts
@@ -64,6 +64,7 @@ import { MatInput } from '@angular/material/input';
 import { MatDivider } from '@angular/material/divider';
 import { MatButton } from '@angular/material/button';
 import { AsyncPipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-edit-user-dialog',
@@ -86,6 +87,7 @@ import { AsyncPipe } from '@angular/common';
         MatButton,
         AsyncPipe,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class EditUserDialogComponent implements OnInit {

--- a/ui/src/app/configuration/security-configuration/role-configuration/role-configuration.component.html
+++ b/ui/src/app/configuration/security-configuration/role-configuration/role-configuration.component.html
@@ -75,12 +75,8 @@
                                         data-cy="role-edit-btn"
                                         (click)="editRole(role)"
                                     >
-                                        <i class="material-icons">edit</i>
-                                        <span
-                                            >&nbsp;{{
-                                                'Edit' | translate
-                                            }}</span
-                                        >
+                                        <mat-icon>edit</mat-icon>
+                                        <span>{{ 'Edit' | translate }}</span>
                                     </button>
                                 </div>
                                 <button
@@ -92,10 +88,8 @@
                                     [disabled]="role.defaultRole"
                                     (click)="deleteRole(role)"
                                 >
-                                    <i class="material-icons">delete</i>
-                                    <span
-                                        >&nbsp;{{ 'Delete' | translate }}</span
-                                    >
+                                    <mat-icon>delete</mat-icon>
+                                    <span>{{ 'Delete' | translate }}</span>
                                 </button>
                             </span>
                         </div>

--- a/ui/src/app/configuration/security-configuration/role-configuration/role-configuration.component.ts
+++ b/ui/src/app/configuration/security-configuration/role-configuration/role-configuration.component.ts
@@ -46,6 +46,7 @@ import {
 } from '@ngbracket/ngx-layout/flex';
 import { MatButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-security-role-config',
@@ -68,6 +69,7 @@ import { MatTooltip } from '@angular/material/tooltip';
         MatButton,
         MatTooltip,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SecurityRoleConfigComponent implements OnInit {

--- a/ui/src/app/configuration/security-configuration/security-configuration.component.html
+++ b/ui/src/app/configuration/security-configuration/security-configuration.component.html
@@ -28,8 +28,7 @@
                 data-cy="add-new-user"
                 (click)="createUserAccount()"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'New' | translate }}</span>
+                <mat-icon>add</mat-icon><span>{{ 'New' | translate }}</span>
             </button>
             <sp-security-user-config></sp-security-user-config>
         </sp-split-section>
@@ -47,8 +46,7 @@
                 color="accent"
                 (click)="createServiceAccount()"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'New' | translate }}</span>
+                <mat-icon>add</mat-icon><span>{{ 'New' | translate }}</span>
             </button>
             <sp-security-service-config></sp-security-service-config>
         </sp-split-section>
@@ -67,8 +65,7 @@
                 data-cy="new-user-group-btn"
                 (click)="createGroup()"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'New' | translate }}</span>
+                <mat-icon>add</mat-icon><span>{{ 'New' | translate }}</span>
             </button>
             <sp-security-user-group-config></sp-security-user-group-config>
         </sp-split-section>
@@ -85,8 +82,7 @@
                 color="accent"
                 (click)="createRole()"
             >
-                <i class="material-icons">add</i
-                ><span>&nbsp;{{ 'New' | translate }}</span>
+                <mat-icon>add</mat-icon><span>{{ 'New' | translate }}</span>
             </button>
             <sp-security-role-config></sp-security-role-config>
         </sp-split-section>

--- a/ui/src/app/configuration/security-configuration/security-configuration.component.ts
+++ b/ui/src/app/configuration/security-configuration/security-configuration.component.ts
@@ -35,6 +35,7 @@ import {
 import { MatButton } from '@angular/material/button';
 import { SecurityAuthenticationConfigurationComponent } from './authentication-configuration/authentication-configuration.component';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-security-configuration',
@@ -52,6 +53,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         SecurityRoleConfigComponent,
         SecurityAuthenticationConfigurationComponent,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SecurityConfigurationComponent implements OnInit {

--- a/ui/src/app/configuration/security-configuration/security-service-configuration/security-service-config.component.html
+++ b/ui/src/app/configuration/security-configuration/security-service-configuration/security-service-config.component.html
@@ -57,12 +57,8 @@
                                         data-cy="service-edit-btn"
                                         (click)="editService(account)"
                                     >
-                                        <i class="material-icons">edit</i>
-                                        <span
-                                            >&nbsp;{{
-                                                'Edit' | translate
-                                            }}</span
-                                        >
+                                        <mat-icon>edit</mat-icon>
+                                        <span>{{ 'Edit' | translate }}</span>
                                     </button>
                                 </div>
                                 <button
@@ -73,10 +69,8 @@
                                     data-cy="service-delete-btn"
                                     (click)="deleteUser(account)"
                                 >
-                                    <i class="material-icons">delete</i>
-                                    <span
-                                        >&nbsp;{{ 'Delete' | translate }}</span
-                                    >
+                                    <mat-icon>delete</mat-icon>
+                                    <span>{{ 'Delete' | translate }}</span>
                                 </button>
                             </span>
                         </div>

--- a/ui/src/app/configuration/security-configuration/security-service-configuration/security-service-config.component.ts
+++ b/ui/src/app/configuration/security-configuration/security-service-configuration/security-service-config.component.ts
@@ -38,6 +38,7 @@ import {
 import { MatButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-security-service-config',
@@ -59,6 +60,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         MatButton,
         MatTooltip,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SecurityServiceConfigComponent extends AbstractSecurityPrincipalConfig<ServiceAccount> {

--- a/ui/src/app/configuration/security-configuration/security-user-configuration/security-user-config.component.html
+++ b/ui/src/app/configuration/security-configuration/security-user-configuration/security-user-config.component.html
@@ -111,12 +111,8 @@
                                         "
                                         (click)="editUser(account)"
                                     >
-                                        <i class="material-icons">edit</i>
-                                        <span
-                                            >&nbsp;{{
-                                                'Edit' | translate
-                                            }}</span
-                                        >
+                                        <mat-icon>edit</mat-icon>
+                                        <span>{{ 'Edit' | translate }}</span>
                                     </button>
                                 </div>
                                 <button
@@ -129,10 +125,8 @@
                                     "
                                     (click)="deleteUser(account)"
                                 >
-                                    <i class="material-icons">delete</i>
-                                    <span
-                                        >&nbsp;{{ 'Delete' | translate }}</span
-                                    >
+                                    <mat-icon>delete</mat-icon>
+                                    <span>{{ 'Delete' | translate }}</span>
                                 </button>
                             </span>
                         </div>

--- a/ui/src/app/configuration/security-configuration/security-user-configuration/security-user-config.component.ts
+++ b/ui/src/app/configuration/security-configuration/security-user-configuration/security-user-config.component.ts
@@ -42,6 +42,7 @@ import {
 import { MatButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-security-user-config',
@@ -64,6 +65,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         MatButton,
         MatTooltip,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SecurityUserConfigComponent extends AbstractSecurityPrincipalConfig<UserAccount> {

--- a/ui/src/app/configuration/security-configuration/user-group-configuration/user-group-configuration.component.html
+++ b/ui/src/app/configuration/security-configuration/user-group-configuration/user-group-configuration.component.html
@@ -64,12 +64,8 @@
                                         data-cy="service-edit-btn"
                                         (click)="editGroup(group)"
                                     >
-                                        <i class="material-icons">edit</i>
-                                        <span
-                                            >&nbsp;{{
-                                                'Edit' | translate
-                                            }}</span
-                                        >
+                                        <mat-icon>edit</mat-icon>
+                                        <span>{{ 'Edit' | translate }}</span>
                                     </button>
                                 </div>
                                 <button
@@ -80,10 +76,8 @@
                                     data-cy="service-delete-btn"
                                     (click)="deleteGroup(group)"
                                 >
-                                    <i class="material-icons">delete</i>
-                                    <span
-                                        >&nbsp;{{ 'Delete' | translate }}</span
-                                    >
+                                    <mat-icon>delete</mat-icon>
+                                    <span>{{ 'Delete' | translate }}</span>
                                 </button>
                             </span>
                         </div>

--- a/ui/src/app/configuration/security-configuration/user-group-configuration/user-group-configuration.component.ts
+++ b/ui/src/app/configuration/security-configuration/user-group-configuration/user-group-configuration.component.ts
@@ -44,6 +44,7 @@ import {
 import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { MatButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-security-user-group-config',
@@ -65,6 +66,7 @@ import { MatTooltip } from '@angular/material/tooltip';
         MatButton,
         MatTooltip,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class SecurityUserGroupConfigComponent implements OnInit {

--- a/ui/src/app/connect/components/existing-adapters/existing-adapters.component.html
+++ b/ui/src/app/connect/components/existing-adapters/existing-adapters.component.html
@@ -32,9 +32,8 @@
             data-cy="connect-create-new-adapter-button"
             (click)="createNewAdapter()"
         >
-            <i class="material-icons" aria-hidden="true">add</i>&nbsp;{{
-                'New adapter' | translate
-            }}
+            <mat-icon aria-hidden="true">add</mat-icon
+            >{{ 'New adapter' | translate }}
         </button>
         <button
             pageActions
@@ -59,7 +58,7 @@
             color="accent"
             (click)="getAdaptersRunning()"
         >
-            <i class="material-icons" aria-hidden="true">refresh</i>
+            <mat-icon aria-hidden="true">refresh</mat-icon>
         </button>
     </sp-page-header>
     <div fxFlex="100" fxLayout="column">
@@ -125,7 +124,7 @@
                                     $event.stopPropagation()
                                 "
                             >
-                                <i class="material-icons">play_arrow</i>
+                                <mat-icon>play_arrow</mat-icon>
                             </button>
                         } @else if (adapter.running) {
                             <button
@@ -139,7 +138,7 @@
                                     $event.stopPropagation()
                                 "
                             >
-                                <i class="material-icons">stop</i>
+                                <mat-icon>stop</mat-icon>
                             </button>
                         }
                     </td>

--- a/ui/src/app/core-ui/static-properties/static-runtime-resolvable-tree-input/static-tree-input-selected-nodes/static-tree-input-selected-nodes.component.html
+++ b/ui/src/app/core-ui/static-properties/static-runtime-resolvable-tree-input/static-tree-input-selected-nodes/static-tree-input-selected-nodes.component.html
@@ -54,7 +54,7 @@
                         [attr.data-cy]="'remove-' + selectedNodeName"
                         (click)="onRemoveSelectedNode(selectedNodeName)"
                     >
-                        <i class="small-icon material-icons">remove</i>
+                        <mat-icon class="small-icon">remove</mat-icon>
                     </button>
                 </div>
             </div>

--- a/ui/src/app/core-ui/static-properties/static-runtime-resolvable-tree-input/static-tree-input-selected-nodes/static-tree-input-selected-nodes.component.ts
+++ b/ui/src/app/core-ui/static-properties/static-runtime-resolvable-tree-input/static-tree-input-selected-nodes/static-tree-input-selected-nodes.component.ts
@@ -25,6 +25,7 @@ import {
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-static-tree-input-selected-nodes',
@@ -40,6 +41,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         MatIconButton,
         MatTooltip,
         TranslatePipe,
+        MatIcon,
     ],
 })
 export class StaticTreeInputSelectedNodesComponent {

--- a/ui/src/app/dashboard/components/overview/dashboard-overview.component.html
+++ b/ui/src/app/dashboard/components/overview/dashboard-overview.component.html
@@ -34,7 +34,7 @@
                 data-cy="open-new-dashboard-dialog"
                 (click)="openNewDashboardDialog()"
             >
-                <i class="material-icons" aria-hidden="true">add</i>
+                <mat-icon aria-hidden="true">add</mat-icon>
                 <span>{{ 'New dashboard' | translate }}</span>
             </button>
         }

--- a/ui/src/app/dashboard/components/overview/dashboard-overview.component.ts
+++ b/ui/src/app/dashboard/components/overview/dashboard-overview.component.ts
@@ -33,6 +33,7 @@ import { Subscription } from 'rxjs';
 import { MatButton } from '@angular/material/button';
 import { ChartRoutingService } from '../../../chart-shared/services/chart-routing.service';
 import { AsyncPipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-dashboard-overview',
@@ -45,6 +46,7 @@ import { AsyncPipe } from '@angular/common';
         DashboardOverviewTableComponent,
         TranslatePipe,
         AsyncPipe,
+        MatIcon,
     ],
 })
 export class DashboardOverviewComponent implements OnInit, OnDestroy {

--- a/ui/src/app/dataset/components/dataset-overview/dataset-overview.component.html
+++ b/ui/src/app/dataset/components/dataset-overview/dataset-overview.component.html
@@ -137,14 +137,13 @@
                                             $event.stopPropagation()
                                         "
                                     >
-                                        <i
-                                            class="material-icons"
+                                        <mat-icon
                                             [ngStyle]="{
                                                 color: configurationEntry.retentionConfigured
                                                     ? 'var(--color-success)'
                                                     : 'var(--color-neutral)',
                                             }"
-                                            >history</i
+                                            >history</mat-icon
                                         >
                                     </button>
                                 } @else {
@@ -188,8 +187,7 @@
                                             )
                                         "
                                     >
-                                        <i
-                                            class="material-icons"
+                                        <mat-icon
                                             [ngStyle]="{
                                                 color:
                                                     configurationEntry.lastRetentionStatus ===
@@ -199,7 +197,7 @@
                                                           ? 'green'
                                                           : 'red',
                                             }"
-                                            >list_alt</i
+                                            >list_alt</mat-icon
                                         >
                                     </button>
                                 } @else {
@@ -355,9 +353,7 @@
                                                     )
                                                 "
                                             >
-                                                <i class="material-icons"
-                                                    >edit</i
-                                                >
+                                                <mat-icon>edit</mat-icon>
                                             </button>
                                         </span>
                                     </div>
@@ -395,9 +391,7 @@
                                                     )
                                                 "
                                             >
-                                                <i class="material-icons"
-                                                    >delete</i
-                                                >
+                                                <mat-icon>delete</mat-icon>
                                             </button>
                                         </span>
                                     </div>
@@ -434,9 +428,7 @@
                                                 )
                                             "
                                         >
-                                            <i class="material-icons"
-                                                >bug_report</i
-                                            >
+                                            <mat-icon>bug_report</mat-icon>
                                         </button>
                                     </span>
                                 </div>

--- a/ui/src/app/editor/components/pipeline-assembly/pipeline-assembly-options/pipeline-assembly-options.component.html
+++ b/ui/src/app/editor/components/pipeline-assembly/pipeline-assembly-options/pipeline-assembly-options.component.html
@@ -42,12 +42,12 @@
         [disabled]="isPipelineAssemblyEmpty()"
     >
         <div fxLayoutAlign="start center" fxLayout="row">
-            <i class="material-icons">visibility</i>
+            <mat-icon>visibility</mat-icon>
             @if (!previewModeActive) {
-                <span>&nbsp;{{ 'Enable live preview' | translate }}</span>
+                <span>{{ 'Enable live preview' | translate }}</span>
             }
             @if (previewModeActive) {
-                <span>&nbsp;{{ 'Disable live preview' | translate }}</span>
+                <span>{{ 'Disable live preview' | translate }}</span>
             }
         </div>
     </button>
@@ -58,7 +58,7 @@
         [matTooltipPosition]="'above'"
         (click)="autoLayout()"
     >
-        <i class="material-icons">settings_overscan</i>
+        <mat-icon>settings_overscan</mat-icon>
     </button>
     <span class="assembly-options-divider"></span>
     <button
@@ -69,8 +69,8 @@
         (click)="openDiscoverDialog()"
         data-cy="sp-editor-add-pipeline-element"
     >
-        <i class="material-icons">add</i>
-        <span>&nbsp;{{ 'Element' | translate }}</span>
+        <mat-icon>add</mat-icon>
+        <span>{{ 'Element' | translate }}</span>
     </button>
     <button
         mat-flat-button
@@ -80,8 +80,8 @@
         (click)="openAddTemplateDialog()"
         data-cy="sp-editor-add-template"
     >
-        <i class="material-icons">add</i>
-        <span>&nbsp;{{ 'From template' | translate }}</span>
+        <mat-icon>add</mat-icon>
+        <span>{{ 'From template' | translate }}</span>
     </button>
     <sp-pipeline-assembly-options-pipeline-cache
         [rawPipelineModel]="rawPipelineModel"
@@ -127,6 +127,6 @@
         (click)="showClearAssemblyConfirmDialog($event)"
         data-cy="clear-assembly-area"
     >
-        <i class="material-icons">clear</i>
+        <mat-icon>clear</mat-icon>
     </button>
 </div>

--- a/ui/src/app/editor/dialog/customize/customize.component.html
+++ b/ui/src/app/editor/dialog/customize/customize.component.html
@@ -180,8 +180,8 @@
                     [disabled]="!formValid"
                     data-cy="sp-element-configuration-save"
                 >
-                    <i class="material-icons">save</i
-                    ><span>&nbsp;{{ 'Save' | translate }}</span>
+                    <mat-icon>save</mat-icon
+                    ><span>{{ 'Save' | translate }}</span>
                 </button>
                 <button
                     mat-button
@@ -201,8 +201,8 @@
                     data-cy="create-template"
                     (click)="triggerTemplateMode()"
                 >
-                    <i class="material-icons">add_circle_outline</i
-                    ><span>&nbsp;{{ 'Create template' | translate }}</span>
+                    <mat-icon>add_circle_outline</mat-icon
+                    ><span>{{ 'Create template' | translate }}</span>
                 </button>
             </div>
         }
@@ -216,8 +216,8 @@
                     [disabled]="!formValid"
                     data-cy="save-template"
                 >
-                    <i class="material-icons">save</i
-                    ><span>&nbsp;{{ 'Save template' | translate }}</span>
+                    <mat-icon>save</mat-icon
+                    ><span>{{ 'Save template' | translate }}</span>
                 </button>
                 <button
                     mat-button

--- a/ui/src/app/editor/dialog/customize/customize.component.ts
+++ b/ui/src/app/editor/dialog/customize/customize.component.ts
@@ -68,6 +68,7 @@ import { MatDivider } from '@angular/material/divider';
 import { MatButton } from '@angular/material/button';
 import { TranslatePipe } from '@ngx-translate/core';
 import { LayoutGapDirective } from '@ngbracket/ngx-layout';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-customize-pipeline-element',
@@ -94,6 +95,7 @@ import { LayoutGapDirective } from '@ngbracket/ngx-layout';
         MatButton,
         TranslatePipe,
         LayoutGapDirective,
+        MatIcon,
     ],
 })
 export class CustomizeComponent implements OnInit, AfterViewInit {

--- a/ui/src/app/pipeline-details/components/pipeline-details-toolbar/pipeline-details-toolbar.component.html
+++ b/ui/src/app/pipeline-details/components/pipeline-details-toolbar/pipeline-details-toolbar.component.html
@@ -25,12 +25,12 @@
         (click)="togglePreviewEmitter.emit()"
     >
         <div fxLayoutAlign="start center" fxLayout="row">
-            <i class="material-icons">visibility</i>
+            <mat-icon>visibility</mat-icon>
             @if (!previewModeActive) {
-                <span>&nbsp;{{ 'Enable live preview' | translate }}</span>
+                <span>{{ 'Enable live preview' | translate }}</span>
             }
             @if (previewModeActive) {
-                <span>&nbsp;{{ 'Disable live preview' | translate }}</span>
+                <span>{{ 'Disable live preview' | translate }}</span>
             }
         </div>
     </button>
@@ -43,8 +43,8 @@
             (click)="openCodeDialogEmitter.emit()"
         >
             <div fxLayoutAlign="start center" fxLayout="row">
-                <i class="material-icons">code</i>
-                <span>&nbsp;{{ 'View pipeline as code' | translate }}</span>
+                <mat-icon>code</mat-icon>
+                <span>{{ 'View pipeline as code' | translate }}</span>
             </div>
         </button>
     }
@@ -57,8 +57,8 @@
             matTooltip="Refresh"
             (click)="reloadMetricsEmitter.emit()"
         >
-            <i class="material-icons">refresh</i>
-            &nbsp;{{ 'Refresh metrics' | translate }}
+            <mat-icon>refresh</mat-icon>
+            {{ 'Refresh metrics' | translate }}
         </button>
         <mat-slide-toggle
             [(ngModel)]="autoRefresh"

--- a/ui/src/app/pipelines/components/functions-overview/functions-overview.component.html
+++ b/ui/src/app/pipelines/components/functions-overview/functions-overview.component.html
@@ -39,7 +39,7 @@
                     matTooltipPosition="above"
                     (click)="showFunctionDetails(spFunction.id)"
                 >
-                    <i class="material-icons">search</i>
+                    <mat-icon>search</mat-icon>
                 </button>
             </div>
         </td>

--- a/ui/src/app/pipelines/components/functions-overview/functions-overview.component.ts
+++ b/ui/src/app/pipelines/components/functions-overview/functions-overview.component.ts
@@ -35,6 +35,7 @@ import {
 } from '@ngbracket/ngx-layout/flex';
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-functions-overview',
@@ -53,6 +54,7 @@ import { MatTooltip } from '@angular/material/tooltip';
         LayoutDirective,
         MatIconButton,
         MatTooltip,
+        MatIcon,
     ],
 })
 export class FunctionsOverviewComponent implements OnInit {

--- a/ui/src/app/pipelines/components/pipeline-overview/pipeline-overview.component.html
+++ b/ui/src/app/pipelines/components/pipeline-overview/pipeline-overview.component.html
@@ -91,8 +91,8 @@
                                 }}"
                                 data-cy="pipeline-warning-icon"
                             >
-                                <i class="material-icons pipeline-notification"
-                                    >warning</i
+                                <mat-icon class="pipeline-notification"
+                                    >warning</mat-icon
                                 >
                             </button>
                         }
@@ -141,7 +141,7 @@
                             !pipeline.valid
                         "
                     >
-                        <i class="material-icons">play_arrow</i>
+                        <mat-icon>play_arrow</mat-icon>
                     </button>
                 }
                 @if (pipeline.running) {
@@ -160,7 +160,7 @@
                         "
                         [disabled]="!hasPipelineWritePrivileges || stopping"
                     >
-                        <i class="material-icons">stop</i>
+                        <mat-icon>stop</mat-icon>
                     </button>
                 }
             </div>

--- a/ui/src/app/pipelines/pipelines.component.html
+++ b/ui/src/app/pipelines/pipelines.component.html
@@ -34,9 +34,8 @@
                 (click)="navigateToPipelineEditor()"
                 data-cy="pipelines-navigate-to-editor"
             >
-                <i class="material-icons" aria-hidden="true">add</i>&nbsp;{{
-                    'New Pipeline' | translate
-                }}
+                <mat-icon aria-hidden="true">add</mat-icon
+                >{{ 'New Pipeline' | translate }}
             </button>
         }
         <button
@@ -49,7 +48,7 @@
             [matTooltip]="'Tutorial' | translate"
             [disabled]="tutorialActive"
         >
-            <i class="material-icons" aria-hidden="true">school</i>
+            <mat-icon aria-hidden="true">school</mat-icon>
         </button>
         <button
             pageActions
@@ -62,7 +61,7 @@
             matTooltipPosition="above"
             (click)="getPipelines()"
         >
-            <i class="material-icons" aria-hidden="true">refresh</i>
+            <mat-icon aria-hidden="true">refresh</mat-icon>
         </button>
     </sp-page-header>
 

--- a/ui/src/app/pipelines/pipelines.component.ts
+++ b/ui/src/app/pipelines/pipelines.component.ts
@@ -49,6 +49,7 @@ import { FunctionsOverviewComponent } from './components/functions-overview/func
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatTab, MatTabGroup } from '@angular/material/tabs';
 import { AsyncPipe } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-pipelines',
@@ -66,6 +67,7 @@ import { AsyncPipe } from '@angular/common';
         MatTab,
         MatTabGroup,
         AsyncPipe,
+        MatIcon,
     ],
 })
 export class PipelinesComponent implements OnInit, OnDestroy {

--- a/ui/src/app/profile/dialog/change-email/change-email-dialog.component.html
+++ b/ui/src/app/profile/dialog/change-email/change-email-dialog.component.html
@@ -114,8 +114,8 @@
                 [disabled]="!parentForm.valid || operationApplied"
                 data-cy="sp-element-edit-user-save"
             >
-                <i class="material-icons">save</i
-                ><span>&nbsp;{{ 'Update email' | translate }}</span>
+                <mat-icon>save</mat-icon
+                ><span>{{ 'Update email' | translate }}</span>
             </button>
             <button
                 mat-button

--- a/ui/src/app/profile/dialog/change-email/change-email-dialog.component.ts
+++ b/ui/src/app/profile/dialog/change-email/change-email-dialog.component.ts
@@ -46,6 +46,7 @@ import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-change-email-dialog',
@@ -65,6 +66,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         FormFieldComponent,
         TranslatePipe,
         SpAlertBannerComponent,
+        MatIcon,
     ],
 })
 export class ChangeEmailDialogComponent implements OnInit {

--- a/ui/src/app/profile/dialog/change-password/change-password-dialog.component.html
+++ b/ui/src/app/profile/dialog/change-password/change-password-dialog.component.html
@@ -112,8 +112,7 @@
                 [disabled]="!parentForm.valid"
                 data-cy="sp-element-edit-user-save"
             >
-                <i class="material-icons">save</i
-                ><span>&nbsp;{{ 'Save' | translate }}</span>
+                <mat-icon>save</mat-icon><span>{{ 'Save' | translate }}</span>
             </button>
             <button
                 mat-button

--- a/ui/src/app/profile/dialog/change-password/change-password-dialog.component.ts
+++ b/ui/src/app/profile/dialog/change-password/change-password-dialog.component.ts
@@ -50,6 +50,7 @@ import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
 import { MatDivider } from '@angular/material/divider';
 import { TranslatePipe } from '@ngx-translate/core';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'sp-change-password-dialog',
@@ -68,6 +69,7 @@ import { TranslatePipe } from '@ngx-translate/core';
         FormFieldComponent,
         TranslatePipe,
         SpAlertBannerComponent,
+        MatIcon,
     ],
 })
 export class ChangePasswordDialogComponent implements OnInit {


### PR DESCRIPTION
<!--
  ~ Licensed to the Apache Software Foundation (ASF) under one or more
  ~ contributor license agreements.  See the NOTICE file distributed with
  ~ this work for additional information regarding copyright ownership.
  ~ The ASF licenses this file to You under the Apache License, Version 2.0
  ~ (the "License"); you may not use this file except in compliance with
  ~ the License.  You may obtain a copy of the License at
  ~
  ~    http://www.apache.org/licenses/LICENSE-2.0
  ~
  ~ Unless required by applicable law or agreed to in writing, software
  ~ distributed under the License is distributed on an "AS IS" BASIS,
  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~
  -->

  <!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/community/get-involved/
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[#<GitHub issue id>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][#<GitHub issue id>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Link the PR to the corresponding GitHub issue (if present) in the `Development` section in the right menu bar.
6. Be sure to keep the PR description updated to reflect all changes.
7. If possible, provide a concise example to reproduce the issue for a faster review.
8. Make sure tests pass via `mvn clean install`.
9. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
<!--
Please clarify what changes you are proposing and describe how those changes will address the issue.
Furthermore, describe potential consequences the changes might have.
-->

Icons inside Angular Material buttons were written as raw `<i class="material-icons">`. Material's spacing and sizing rules are scoped to `.mat-icon`, so those buttons got neither the 8px gap nor the `1.125rem` size clamp. This PR converts them to `<mat-icon>` and removes the manual `&nbsp;` spacers added to compensate.



### Changes

- Converts 76 icons across 44 templates to `<mat-icon>`, adding `MatIcon` to the 30 components that lacked it.
- Removes 48 `&nbsp;` spacers that would otherwise stack on the restored margin.
- Leaves non-Material buttons alone — they define their own `gap` and icon size.

<img width="1506" height="234" alt="grafik" src="https://github.com/user-attachments/assets/aaa267ce-3ee2-422f-95f7-80864ac27e45" />


### Remarks
<!--
Is there anything left we need to pay attention on?
Are there some references that might be important? E.g. links to Confluence, or discussions
on the mailing list or GitHub.
-->
PR introduces (a) breaking change(s): yes

PR introduces (a) deprecation(s): yes
