### PR TITLE
fix(#4915): handle chart discard dialog in Cypress

### DIFF
--- a/ui/cypress/support/utils/chart/ChartBtns.ts
+++ b/ui/cypress/support/utils/chart/ChartBtns.ts
@@ -38,7 +38,7 @@ export class ChartBtns {
     }
 
     public static discardDashboard() {
-        return cy.dataCy('save-data-explorer-go-back-to-overview');
+        return cy.visit('#/dashboard');
     }
 
     public static deleteDashboardBtn(dashboardName) {
@@ -186,11 +186,11 @@ export class ChartBtns {
     }
 
     public static goBackToOverviewBtn() {
-        return cy.dataCy('save-data-explorer-go-back-to-overview');
+        return cy.visit('#/chart');
     }
 
     public static discardChartBtn() {
-        return cy.dataCy('save-data-explorer-go-back-to-overview');
+        return cy.visit('#/chart');
     }
 
     public static chartDataPreview() {

--- a/ui/cypress/support/utils/chart/ChartUtils.ts
+++ b/ui/cypress/support/utils/chart/ChartUtils.ts
@@ -34,11 +34,12 @@ export class ChartUtils {
         if (!discardUnsavedChanges) {
             return;
         }
-        cy.location('hash', { timeout: 10000 }).then(hash => {
-            if (hash.startsWith('#/chart/')) {
-                SharedBtns.confirmDialogCancelBtn()
-                    .should('be.visible')
-                    .click();
+
+        cy.get('sp-chart-overview, [data-cy="cancel-delete"]:visible', {
+            timeout: 10000,
+        }).then($elements => {
+            if ($elements.filter('[data-cy="cancel-delete"]').length > 0) {
+                SharedBtns.confirmDialogCancelBtn().click();
             }
         });
         cy.location('hash', { timeout: 10000 }).should('eq', '#/chart');
@@ -414,7 +415,7 @@ export class ChartUtils {
      * Leaves the chart editor of a copy without saving it.
      */
     public static discardChartFromExisting() {
-        ChartBtns.discardChartBtn().click();
+        ChartBtns.goBackToOverviewBtn();
         SharedBtns.confirmDialogCancelBtn().should('be.visible').click();
         ChartBtns.openNewChartBtn().should('be.visible');
     }
@@ -581,7 +582,7 @@ export class ChartUtils {
     }
 
     public static goBackToOverview() {
-        ChartBtns.goBackToOverviewBtn().click();
+        ChartUtils.goToDatalake();
     }
 
     public static addNewChart() {

--- a/ui/cypress/tests/userManagement/testUserRoleDataset.spec.ts
+++ b/ui/cypress/tests/userManagement/testUserRoleDataset.spec.ts
@@ -150,7 +150,7 @@ describe('Test Dataset Permissions', () => {
 
         assertAlertBanner(true);
 
-        ChartBtns.discardDashboard().click();
+        ChartBtns.discardDashboard();
 
         SharedBtns.confirmDialogCancelBtn().click();
 
@@ -170,10 +170,10 @@ describe('Test Dataset Permissions', () => {
         ChartBtns.openNewChartBtn().click();
         if (!available) {
             cy.get('sp-alert-banner').should('be.visible');
-            ChartBtns.discardChartBtn().click();
+            ChartUtils.goToDatalake();
         } else {
             ChartUtils.selectDataSet(datasetName);
-            ChartBtns.discardChartBtn().click();
+            ChartUtils.goToDatalake();
             ChartUtils.createTableChart(datasetName, true);
             ChartUtils.saveChartConfiguration(false, false, 'test');
         }


### PR DESCRIPTION
Updated Cypress for the redesigned chart and dashboard navigation, ensuring tests can discard unsaved edits and return to their respective overviews. 
Changes
- Replaces removed overview-button selectors with route-based chart and dashboard navigation in Cypress helpers.
- Handles the optional unsaved-changes dialog before asserting the chart overview.