### PR TITLE
ci: added PR naming validation

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Title Validation
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Conventional Commit title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|deps|docs|feat|fix|perf|refactor|revert|style|test)(\(#[0-9]+\))?!?: .{1,50}$'
+
+          if [[ ! "$PR_TITLE" =~ $pattern || "$PR_TITLE" == *. ]]; then
+            echo "Invalid pull request title: $PR_TITLE"
+            echo "Use: type(#issue): subject"
+            echo "The issue number and ! are optional; the subject must be 1-50 characters and must not end in a period."
+            echo "Allowed types: build, chore, ci, deps, docs, feat, fix, perf, refactor, revert, style, test"
+            exit 1
+          fi


### PR DESCRIPTION
- Adds a pull request workflow that validates titles when PRs are opened, edited, or reopened.
- Enforces the format type(#issue): subject; both (#issue) and ! are optional.
- Allows: build, chore, ci, deps, docs, feat, fix, perf, refactor, revert, style, and test.
- Requires a 1–50 character subject with no trailing period.