### PR TITLE
[#4885] Return complete adapter descriptions in Python client

### DIFF
--- a/streampipes-client-python/streampipes/endpoint/api/adapter.py
+++ b/streampipes-client-python/streampipes/endpoint/api/adapter.py
@@ -23,7 +23,7 @@ from streampipes.endpoint.endpoint import APIEndpoint
 from streampipes.model.compact import CompactAdapter
 from streampipes.model.container import Adapters
 from streampipes.model.container.resource_container import ResourceContainer
-from streampipes.model.resource import AdapterSummary
+from streampipes.model.resource import AdapterDescription
 
 __all__ = ["AdapterEndpoint"]
 
@@ -54,12 +54,13 @@ class AdapterEndpoint(APIEndpoint):
         )
         return Adapters.from_json(json_string=response.text)
 
-    def get(self, identifier: str, **kwargs) -> AdapterSummary:
-        """Return one adapter summary by identifier."""
-        for adapter in self.all():
-            if adapter.element_id == identifier:
-                return adapter
-        raise KeyError(f"No adapter summary found for identifier '{identifier}'.")
+    def get(self, identifier: str, **kwargs) -> AdapterDescription:
+        """Return one complete adapter description by identifier."""
+        response = self._make_request(
+            request_method=self._parent_client.request_session.get,
+            url=f"{self.build_url()}/{identifier}",
+        )
+        return AdapterDescription.model_validate(response.json())
 
     def post(self, resource: object) -> None:
         """Create an adapter from its compact representation."""

--- a/streampipes-client-python/streampipes/model/resource/__init__.py
+++ b/streampipes-client-python/streampipes/model/resource/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-from .adapter import AdapterSummary
+from .adapter import AdapterDescription, AdapterSummary
 from .data_lake_measure import DataLakeMeasure
 from .data_series import DataSeries
 from .data_stream import DataStream
@@ -24,6 +24,7 @@ from .pipeline import PipelineSummary
 from .version import Version
 
 __all__ = [
+    "AdapterDescription",
     "AdapterSummary",
     "DataLakeMeasure",
     "DataSeries",

--- a/streampipes-client-python/streampipes/model/resource/adapter.py
+++ b/streampipes-client-python/streampipes/model/resource/adapter.py
@@ -15,11 +15,15 @@
 # limitations under the License.
 #
 
-"""Summary representation of an adapter."""
+"""Representations of adapters returned by the adapter APIs."""
+
+from typing import Any
+
+from pydantic import ConfigDict, Field
 
 from streampipes.model.resource.resource import Resource
 
-__all__ = ["AdapterSummary"]
+__all__ = ["AdapterDescription", "AdapterSummary"]
 
 
 class AdapterSummary(Resource):
@@ -41,3 +45,14 @@ class AdapterSummary(Resource):
             **self.model_dump(exclude={"included_assets"}),
             "num_included_assets": len(self.included_assets) if self.included_assets is not None else 0,
         }
+
+
+class AdapterDescription(AdapterSummary):
+    """Complete adapter representation returned by the detail endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    class_name: str | None = Field(default=None, alias="@class")
+    data_stream: dict[str, Any] | None = None
+    config: list[dict[str, Any]] = Field(default_factory=list)
+    selected_endpoint_url: str | None = None

--- a/streampipes-client-python/tests/endpoint/test_adapter.py
+++ b/streampipes-client-python/tests/endpoint/test_adapter.py
@@ -24,7 +24,7 @@ from streampipes.client.config import StreamPipesClientConfig
 from streampipes.client.credential_provider import StreamPipesApiKeyCredentials
 from streampipes.model.compact import CompactAdapter
 from streampipes.model.container import Adapters
-from streampipes.model.resource import AdapterSummary, DataStream
+from streampipes.model.resource import AdapterDescription, AdapterSummary, DataStream
 
 
 class TestAdapterEndpoint(TestCase):
@@ -69,19 +69,33 @@ class TestAdapterEndpoint(TestCase):
         self.assertIsInstance(adapters, Adapters)
         self.assertEqual(adapters.total_count, 1)
         self.assertIsInstance(adapters[0], AdapterSummary)
-        self.request_session.get.assert_called_with(url=f"{self.base_url}/summary")
+        self.request_session.get.assert_called_once_with(url=f"{self.base_url}/summary")
+
+    def test_get_returns_complete_adapter_description(self):
+        description = {
+            **self.summary,
+            "@class": "org.apache.streampipes.model.connect.adapter.AdapterDescription",
+            "dataStream": {"elementId": "stream-1", "name": "Adapter stream"},
+            "config": [
+                {
+                    "@class": "org.apache.streampipes.model.staticproperty.FreeTextStaticProperty",
+                    "internalName": "server",
+                    "value": "opc.tcp://server-a",
+                }
+            ],
+            "selectedEndpointUrl": "http://worker:8090",
+            "selectedServiceId": "worker-1",
+        }
+        self.request_session.get.return_value.json.return_value = description
 
         adapter = self.client.adapterApi.get("adapter-1")
 
-        self.assertIsInstance(adapter, AdapterSummary)
-        self.assertEqual(adapter.element_id, "adapter-1")
-        self.request_session.get.assert_called_with(url=f"{self.base_url}/summary")
-
-    def test_get_missing_summary(self):
-        self.request_session.get.return_value.text = json.dumps({"resources": [], "totalCount": 0})
-
-        with self.assertRaises(KeyError):
-            self.client.adapterApi.get("missing")
+        self.assertIsInstance(adapter, AdapterDescription)
+        self.assertEqual(adapter.data_stream, description["dataStream"])
+        self.assertEqual(adapter.config, description["config"])
+        self.assertEqual(adapter.selected_endpoint_url, "http://worker:8090")
+        self.assertEqual(adapter.model_dump(by_alias=True)["selectedServiceId"], "worker-1")
+        self.request_session.get.assert_called_once_with(url=f"{self.base_url}/adapter-1")
 
     def test_compact_post(self):
         compact_adapter = CompactAdapter(


### PR DESCRIPTION
### Purpose

Fixes #4885.

Make `adapterApi.get(identifier)` retrieve the complete adapter resource from `/api/v2/connect/master/adapters/{identifier}` and return an `AdapterDescription`. This preserves adapter configuration and data-stream detail needed for automation and reporting, while `adapterApi.all()` continues to return summary resources.

### Remarks

`AdapterDescription` extends `AdapterSummary`, preserves unmodeled response fields for forward compatibility, and keeps the summary fields available to existing callers.

Validation:

- Manually exercised the real Python client against a local HTTP endpoint serving an adapter detail response. The client requested `/api/v2/connect/master/adapters/adapter-1` and retained the OPC UA server configuration and data-stream detail.
- `make unit-tests` passed: 73 tests, 93.72% total coverage.
- Focused mypy, flake8, isort, and Black checks passed for the changed files.
- The full `make check` currently stops at existing project-wide mypy errors in untouched files. Repository-wide flake8 also reports two existing violations in unchanged `resource_container.py` and `exceptions.py`.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
