### PR TITLE
[#4727] Return empty for unavailable data lake measures

### DIFF
--- a/streampipes-client/src/main/java/org/apache/streampipes/client/api/DataLakeMeasureApi.java
+++ b/streampipes-client/src/main/java/org/apache/streampipes/client/api/DataLakeMeasureApi.java
@@ -20,8 +20,11 @@ package org.apache.streampipes.client.api;
 
 import org.apache.streampipes.client.model.StreamPipesClientConfig;
 import org.apache.streampipes.client.util.StreamPipesApiPath;
+import org.apache.streampipes.commons.exceptions.SpHttpErrorStatusCode;
 import org.apache.streampipes.model.datalake.DataLakeMeasure;
 import org.apache.streampipes.model.shared.annotation.ExposedToScripts;
+
+import org.apache.http.HttpStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,7 +45,14 @@ public class DataLakeMeasureApi extends AbstractTypedClientApi<DataLakeMeasure>
   @Override
   @ExposedToScripts
   public Optional<DataLakeMeasure> getByDatasetName(String datasetName) {
-    return getSingle(getBaseResourcePath().addToPath("byName").addToPath(datasetName));
+    try {
+      return getSingle(getBaseResourcePath().addToPath("byName").addToPath(datasetName));
+    } catch (SpHttpErrorStatusCode e) {
+      if (e.getHttpStatusCode() == HttpStatus.SC_FORBIDDEN) {
+        return Optional.empty();
+      }
+      throw e;
+    }
   }
 
   @Override

--- a/streampipes-client/src/test/java/org/apache/streampipes/client/api/DataLakeMeasureApiTest.java
+++ b/streampipes-client/src/test/java/org/apache/streampipes/client/api/DataLakeMeasureApiTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.streampipes.client.api;
+
+import org.apache.streampipes.client.api.config.ClientConnectionUrlResolver;
+import org.apache.streampipes.client.credentials.StreamPipesApiKeyCredentials;
+import org.apache.streampipes.client.model.StreamPipesClientConfig;
+import org.apache.streampipes.commons.exceptions.SpHttpErrorStatusCode;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DataLakeMeasureApiTest {
+
+  private HttpServer server;
+
+  @AfterEach
+  void stopServer() {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void returnsEmptyForForbiddenDatasetName() throws Exception {
+    startServer(403);
+
+    assertTrue(api().getByDatasetName("missing").isEmpty());
+  }
+
+  @Test
+  void preservesUnexpectedErrorResponses() throws Exception {
+    startServer(500);
+
+    SpHttpErrorStatusCode exception = assertThrows(SpHttpErrorStatusCode.class,
+        () -> api().getByDatasetName("missing"));
+    assertEquals(500, exception.getHttpStatusCode());
+  }
+
+  private void startServer(int statusCode) throws IOException {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    server.createContext("/streampipes-backend/api/v4/datalake/measure/byName/missing", exchange -> {
+      exchange.sendResponseHeaders(statusCode, -1);
+      exchange.close();
+    });
+    server.start();
+  }
+
+  private DataLakeMeasureApi api() {
+    return new DataLakeMeasureApi(new StreamPipesClientConfig(new ClientConnectionUrlResolver() {
+      @Override
+      public StreamPipesApiKeyCredentials getCredentials() {
+        return new StreamPipesApiKeyCredentials("service", "secret");
+      }
+
+      @Override
+      public String getBaseUrl() {
+        return "http://localhost:" + server.getAddress().getPort();
+      }
+    }));
+  }
+}


### PR DESCRIPTION
### Purpose

Fixes #4727.

`DataLakeMeasureApi#getByDatasetName` returns an `Optional`, but a missing or inaccessible data lake measure can be reported by the backend as HTTP 403. The client now maps that response to `Optional.empty()` while preserving unexpected HTTP failures as exceptions.

### Remarks

Validation completed on the remote Linux host:

- Focused `DataLakeMeasureApiTest` passed both the 403-to-empty and 500-propagation cases.
- `mvn clean verify` passed across all 96 modules.
- Manually ran a standalone Java client against a local HTTP endpoint: a 403 returned `Optional.empty()` and a 500 still raised `SpHttpErrorStatusCode`.
- A full Docker stack could not be started because its daemon was unavailable on the host.

PR introduces (a) breaking change(s): no

PR introduces (a) deprecation(s): no
